### PR TITLE
Fix cmd/jocko/main.go

### DIFF
--- a/cmd/jocko/main.go
+++ b/cmd/jocko/main.go
@@ -16,11 +16,11 @@ import (
 var (
 	logDir      = kingpin.Flag("logdir", "A comma separated list of directories under which to store log files").Default("/tmp/jocko").String()
 	tcpAddr     = kingpin.Flag("tcpaddr", "HTTP Address to listen on").String()
-	raftDir     = kingpin.Flag("raftdir", "Directory for raft to store data").String()
+	raftDir     = kingpin.Flag("raftdir", "Directory for Raft to store data").String()
 	raftAddr    = kingpin.Flag("raftaddr", "Address for Raft to bind on").String()
 	raftPort    = kingpin.Flag("raftport", "Port for Raft to bind on").Int()
 	serfPort    = kingpin.Flag("serfport", "Port for Serf to bind on").Default("7946").Int()
-	serfMembers = kingpin.Flag("serfmembers", "List of existing serf members").Strings()
+	serfMembers = kingpin.Flag("serfmembers", "List of existing Serf members").Strings()
 	brokerID    = kingpin.Flag("id", "Broker ID").Int32()
 	debugLogs   = kingpin.Flag("debug", "Enable debug logs").Default("false").Bool()
 )
@@ -53,11 +53,13 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error with new broker: %s\n", err)
 		os.Exit(1)
 	}
-	server := server.New(*tcpAddr, store, logger)
-	if err := server.Start(); err != nil {
+	srv := server.New(*tcpAddr, store, logger)
+	if err := srv.Start(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error starting server: %s\n", err)
 		os.Exit(1)
 	}
+
+	defer srv.Close()
 
 	gracefully.Timeout = 10 * time.Second
 	gracefully.Shutdown()
@@ -65,5 +67,4 @@ func main() {
 	if err := store.Shutdown(); err != nil {
 		panic(err)
 	}
-	server.Close()
 }


### PR DESCRIPTION
* Rename the variable name of `server` to `srv` because it shadows the package declaration of `github.com/travisjeffery/jocko/server`
* Defer the call of `srv.Close()` so that it is called surely even if the panic occur
* Capitalize the `raft` and `serf` in string values