### PR TITLE
make arguments -- especially network addresses -- consistent

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -42,7 +42,6 @@ type Broker struct {
 	devDisableBootstrap bool
 
 	raft          *raft.Raft
-	raftPort      int
 	raftPeers     raft.PeerStore
 	raftTransport *raft.NetworkTransport
 	raftStore     *raftboltdb.BoltStore
@@ -50,7 +49,6 @@ type Broker struct {
 	raftConfig    *raft.Config
 
 	serf                  *serf.Serf
-	serfPort              int
 	serfAddr              string
 	serfReconcileCh       chan serf.Member
 	serfReconcileInterval time.Duration
@@ -71,8 +69,7 @@ const (
 func New(id int32, opts ...BrokerFn) (*Broker, error) {
 	var err error
 	b := &Broker{
-		serfPort:              7946,
-		serfAddr:              "0.0.0.0",
+		serfAddr:              "0.0.0.0:7946",
 		raftConfig:            raft.DefaultConfig(),
 		replicationManager:    newReplicationManager(),
 		peers:                 make(map[int32]*jocko.BrokerConn),

--- a/broker/option.go
+++ b/broker/option.go
@@ -26,15 +26,9 @@ func Port(port int) BrokerFn {
 	}
 }
 
-func RaftPort(raftPort int) BrokerFn {
+func SerfAddr(serfAddr string) BrokerFn {
 	return func(b *Broker) {
-		b.raftPort = raftPort
-	}
-}
-
-func SerfPort(serfPort int) BrokerFn {
-	return func(b *Broker) {
-		b.serfPort = serfPort
+		b.serfAddr = serfAddr
 	}
 }
 

--- a/broker/raft.go
+++ b/broker/raft.go
@@ -41,7 +41,10 @@ func newCommand(cmd CmdType, data interface{}) (c command, err error) {
 
 // setupRaft is used to configure and create the raft node
 func (b *Broker) setupRaft() (err error) {
-	addr := &net.TCPAddr{IP: net.ParseIP(b.bindAddr), Port: b.raftPort}
+	addr, err := net.ResolveTCPAddr("tcp", b.bindAddr)
+	if err != nil {
+		return errors.Wrap(err, "resolving raft addr failed")
+	}
 
 	if b.raftTransport == nil {
 		b.raftTransport, err = raft.NewTCPTransport(addr.String(), nil, 3, timeout, os.Stderr)

--- a/broker/replicator_test.go
+++ b/broker/replicator_test.go
@@ -23,9 +23,10 @@ func TestBroker_Replicate(t *testing.T) {
 
 	s0.WaitForLeader(10 * time.Second)
 
-	addr := &net.TCPAddr{IP: net.ParseIP(s0.bindAddr), Port: s0.port}
+	addr, err := net.ResolveTCPAddr("tcp", s0.bindAddr)
+	assert.NoError(t, err)
 	srv := server.New(addr.String(), s0, logger)
-	err := srv.Start()
+	err = srv.Start()
 	assert.NoError(t, err)
 
 	tp := &jocko.Partition{

--- a/broker/serf_test.go
+++ b/broker/serf_test.go
@@ -128,10 +128,9 @@ func testServer(t *testing.T, id int, opts ...BrokerFn) *Broker {
 	opts = append(opts, []BrokerFn{
 		DataDir(filepath.Join(dataDir, idStr)),
 		LogDir(filepath.Join(dataDir, idStr)),
-		BindAddr("127.0.0.1"),
+		BindAddr("127.0.0.1:" + strconv.Itoa(getRaftPort())),
 		Port(getPort()),
-		SerfPort(getSerfPort()),
-		RaftPort(getRaftPort()),
+		SerfAddr("127.0.0.1:" + strconv.Itoa(getSerfPort())),
 		Logger(logger),
 		RaftConfig(raftConf),
 	}...)
@@ -160,9 +159,8 @@ func getPort() int {
 }
 
 func testJoin(t *testing.T, s0 *Broker, other ...*Broker) {
-	addr := fmt.Sprintf("127.0.0.1:%d", s0.serfPort)
 	for _, s1 := range other {
-		num, err := s1.Join(addr)
+		num, err := s1.Join(s0.serfAddr)
 		assert.NoError(t, err)
 		assert.Equal(t, 1, num)
 	}

--- a/cmd/jocko/main.go
+++ b/cmd/jocko/main.go
@@ -14,14 +14,12 @@ import (
 )
 
 var (
-	logDir      = kingpin.Flag("logdir", "A comma separated list of directories under which to store log files").Default("/tmp/jocko").String()
-	tcpAddr     = kingpin.Flag("tcpaddr", "HTTP Address to listen on").String()
-	raftDir     = kingpin.Flag("raftdir", "Directory for Raft to store data").String()
-	raftAddr    = kingpin.Flag("raftaddr", "Address for Raft to bind on").String()
-	raftPort    = kingpin.Flag("raftport", "Port for Raft to bind on").Int()
-	serfPort    = kingpin.Flag("serfport", "Port for Serf to bind on").Default("7946").Int()
-	serfMembers = kingpin.Flag("serfmembers", "List of existing Serf members").Strings()
-	brokerID    = kingpin.Flag("id", "Broker ID").Int32()
+	logDir      = kingpin.Flag("logdir", "A directory under which to store log files").Default("/tmp/jocko").String()
+	tcpAddr     = kingpin.Flag("tcpaddr", "Address for HTTP to bind").Default(":8080").String()
+	raftAddr    = kingpin.Flag("raftaddr", "Address for Raft to bind").Default(":9020").String()
+	serfAddr    = kingpin.Flag("serfaddr", "Address for Serf to bind").Default(":7946").String()
+	serfMembers = kingpin.Flag("serfmembers", "Comma-separated list of existing Serf members").Strings()
+	brokerID    = kingpin.Flag("id", "Broker ID").Default("1").Int32()
 	debugLogs   = kingpin.Flag("debug", "Enable debug logs").Default("false").Bool()
 )
 
@@ -44,8 +42,7 @@ func main() {
 		broker.LogDir(*logDir),
 		broker.Logger(logger),
 		broker.BindAddr(*raftAddr),
-		broker.RaftPort(*raftPort),
-		broker.SerfPort(*serfPort),
+		broker.SerfAddr(*serfAddr),
 		broker.SerfMembers(*serfMembers),
 		broker.Port(addr.Port),
 	)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -194,9 +194,8 @@ func setup(t *testing.T) (*net.TCPConn, func()) {
 	store, err := broker.New(0,
 		broker.DataDir(dataDir),
 		broker.LogDir(dataDir),
-		broker.BindAddr("127.0.0.1"),
+		broker.BindAddr("127.0.0.1:8001"),
 		broker.Port(8000),
-		broker.RaftPort(8001),
 		broker.Logger(logger))
 	assert.NoError(t, err)
 


### PR DESCRIPTION
@travisjeffery I didn't manage to get tests passing, but then I switched back to master and they weren't passing there either OMB so I'm not sure what's up.

Generally a few things I was trying to preserve:
- free(ish) IPv6 compatibility by parsing with `net.ResolveTCPAddr`
- for default arguments: you can leave off the host (":port") and still have the same default address (all interfaces 0.0.0.0)