### PR TITLE
Broker cleanup 2

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -15,6 +15,12 @@ var (
 	ErrTopicExists = errors.New("topic exists already")
 )
 
+const (
+	addPartition jocko.RaftCmdType = iota
+	deleteTopic
+	// others
+)
+
 type Broker struct {
 	*replicationManager
 	mu     sync.RWMutex

--- a/broker/fsm.go
+++ b/broker/fsm.go
@@ -26,12 +26,6 @@ func (s *Broker) Snapshot() (raft.FSMSnapshot, error) {
 	return &FSMSnapshot{}, nil
 }
 
-const (
-	addPartition jocko.RaftCmdType = iota
-	deleteTopic
-	// others
-)
-
 func (s *Broker) raftApply(cmd jocko.RaftCmdType, data interface{}) error {
 	var b []byte
 	b, err := json.Marshal(data)
@@ -47,11 +41,7 @@ func (s *Broker) raftApply(cmd jocko.RaftCmdType, data interface{}) error {
 }
 
 // Apply raft command as fsm
-func (s *Broker) Apply(l *raft.Log) interface{} {
-	var c jocko.RaftCommand
-	if err := json.Unmarshal(l.Data, &c); err != nil {
-		panic(errors.Wrap(err, "json unmarshal failed"))
-	}
+func (s *Broker) Apply(c jocko.RaftCommand) {
 	s.logger.Debug("broker/apply cmd [%d]", c.Cmd)
 	switch c.Cmd {
 	case addPartition:
@@ -79,5 +69,4 @@ func (s *Broker) Apply(l *raft.Log) interface{} {
 			panic(errors.Wrap(err, "topic delete failed"))
 		}
 	}
-	return nil
 }

--- a/broker/leader.go
+++ b/broker/leader.go
@@ -4,9 +4,7 @@ import (
 	"net"
 	"time"
 
-	"github.com/hashicorp/serf/serf"
 	"github.com/travisjeffery/jocko"
-	jockoserf "github.com/travisjeffery/jocko/serf"
 )
 
 // monitorLeadership is used to monitor if we acquire or lose our role as the
@@ -107,9 +105,9 @@ func (b *Broker) reconcileMember(member *jocko.ClusterMember) error {
 	}
 	var err error
 	switch member.Status {
-	case serf.StatusAlive:
+	case jocko.StatusAlive:
 		err = b.addRaftPeer(member)
-	case serf.StatusLeft, jockoserf.StatusReap:
+	case jocko.StatusLeft, jocko.StatusReap:
 		err = b.removeRaftPeer(member)
 	}
 	if err != nil {

--- a/broker/replicator_test.go
+++ b/broker/replicator_test.go
@@ -37,6 +37,8 @@ func TestBroker_Replicate(t *testing.T) {
 	err = s0.AddPartition(tp)
 	assert.NoError(t, err)
 
+	time.Sleep(time.Second * 1)
+
 	p, err := s0.Partition("test", 0)
 	assert.NoError(t, err)
 

--- a/broker/util.go
+++ b/broker/util.go
@@ -1,9 +1,12 @@
 package broker
 
 import (
+	"encoding/json"
 	"net"
 	"strconv"
 	"time"
+
+	"github.com/pkg/errors"
 )
 
 const (
@@ -57,4 +60,15 @@ func getPortFromAddr(addr string) (int, error) {
 		return 0, err
 	}
 	return port, nil
+}
+
+func unmarshalData(data *json.RawMessage, p interface{}) error {
+	b, err := data.MarshalJSON()
+	if err != nil {
+		return errors.Wrap(err, "json marshal failed")
+	}
+	if err := json.Unmarshal(b, p); err != nil {
+		return errors.Wrap(err, "json unmarshal failed")
+	}
+	return nil
 }

--- a/jocko.go
+++ b/jocko.go
@@ -11,6 +11,8 @@ import (
 	"github.com/travisjeffery/jocko/protocol"
 )
 
+// CommitLog is the interface that wraps the commit log's methods and
+// is used to manage a partition's data.
 type CommitLog interface {
 	Init() error
 	Open() error
@@ -22,6 +24,7 @@ type CommitLog interface {
 	Append([]byte) (int64, error)
 }
 
+// Partition is the unit of storage in Jocko.
 type Partition struct {
 	Topic           string  `json:"topic"`
 	ID              int32   `json:"id"`
@@ -36,6 +39,7 @@ type Partition struct {
 	Conn io.ReadWriter `json:"-"`
 }
 
+// NewPartition is used to create a new partition.
 func NewPartition(topic string, id int32) *Partition {
 	return &Partition{
 		ID:    id,
@@ -43,27 +47,36 @@ func NewPartition(topic string, id int32) *Partition {
 	}
 }
 
+// Delete is used to delete the partition's data/commitlog.
 func (p *Partition) Delete() error {
 	return p.CommitLog.DeleteAll()
 }
 
+// NewReader is used to create a reader at the given offset and will
+// read up to maxBytes.
 func (p *Partition) NewReader(offset int64, maxBytes int32) (io.Reader, error) {
 	return p.CommitLog.NewReader(offset, maxBytes)
 }
 
-// Strings returns the topic/Partition as a string.
+// String returns the topic/Partition as a string.
 func (r *Partition) String() string {
 	return fmt.Sprintf("%s/%d", r.Topic, r.ID)
 }
 
+// IsOpen is used to check whether the partition's commit log has been
+// initialized.
 func (r *Partition) IsOpen() bool {
 	return r.CommitLog != nil
 }
 
+// IsLeader is used to check if the given broker ID's the partition's
+// leader.
 func (r *Partition) IsLeader(id int32) bool {
 	return r.Leader == id
 }
 
+// IsFollowing is used to check if the given broker ID's should
+// follow/replicate the leader.
 func (r *Partition) IsFollowing(id int32) bool {
 	for _, b := range r.Replicas {
 		if b == id {
@@ -73,35 +86,43 @@ func (r *Partition) IsFollowing(id int32) bool {
 	return false
 }
 
+// HighWatermark is used to get the newest offset of the partition.
 func (p *Partition) HighWatermark() int64 {
 	return p.CommitLog.NewestOffset()
 }
 
+// LowWatermark is used to oldest offset of the partition.
 func (p *Partition) LowWatermark() int64 {
 	return p.CommitLog.OldestOffset()
 }
 
+// TruncateTo is used to truncate the partition's logs before the given offset.
 func (p *Partition) TruncateTo(offset int64) error {
 	return p.CommitLog.TruncateTo(offset)
 }
 
+// Write is used to directly write the given bytes to the partition's leader.
 func (p *Partition) Write(b []byte) (int, error) {
 	return p.Conn.Write(b)
 }
 
+// Write is used to directly read the given bytes from the partition's leader.
 func (p *Partition) Read(b []byte) (int, error) {
 	return p.Conn.Read(b)
 }
 
+// Append is used to append message sets to the partition.
 func (p *Partition) Append(ms []byte) (int64, error) {
 	return p.CommitLog.Append(ms)
 }
 
+// LeaderID is used to get the partition's leader broker ID.
 func (p *Partition) LeaderID() int32 {
 	return p.Leader
 }
 
-// Serf manages the cluster membership for Jocko nodes
+// Serf is the interface that wraps Serf methods and is used to manage
+// the cluster membership for Jocko nodes.
 type Serf interface {
 	Bootstrap(node *ClusterMember, reconcileCh chan<- *ClusterMember) error
 	Cluster() []*ClusterMember
@@ -119,7 +140,8 @@ type RaftCommand struct {
 	Data *json.RawMessage `json:"data"`
 }
 
-// Raft manages consensus for Jocko cluster
+// Raft is the interface that wraps Raft's methods and is used to
+// manage consensus for the Jocko cluster.
 type Raft interface {
 	Bootstrap(peers []*ClusterMember, fsm raft.FSM, leaderCh chan<- bool) (err error)
 	Apply(cmd RaftCommand) error
@@ -132,6 +154,7 @@ type Raft interface {
 	Addr() string
 }
 
+// Broker is the interface that wraps the Broker's methods.
 type Broker interface {
 	ID() int32
 	IsController() bool
@@ -148,6 +171,8 @@ type Broker interface {
 	IsLeaderOfPartition(topic string, id int32, leaderID int32) bool
 }
 
+// ClusterMember is used as a wrapper around a broker's info and a
+// connection to it.
 type ClusterMember struct {
 	ID   int32  `json:"id"`
 	Port int    `json:"port"`
@@ -160,10 +185,12 @@ type ClusterMember struct {
 	conn net.Conn
 }
 
+// Addr is used to get the address of the member.
 func (b *ClusterMember) Addr() *net.TCPAddr {
 	return &net.TCPAddr{IP: net.ParseIP(b.IP), Port: b.Port}
 }
 
+// Write is used to write the member.
 func (b *ClusterMember) Write(p []byte) (int, error) {
 	if b.conn == nil {
 		if err := b.connect(); err != nil {
@@ -173,6 +200,7 @@ func (b *ClusterMember) Write(p []byte) (int, error) {
 	return b.conn.Write(p)
 }
 
+// Read is used to read from the member.
 func (b *ClusterMember) Read(p []byte) (int, error) {
 	if b.conn == nil {
 		if err := b.connect(); err != nil {

--- a/jocko.go
+++ b/jocko.go
@@ -154,7 +154,7 @@ type RaftCommand struct {
 // Raft is the interface that wraps Raft's methods and is used to
 // manage consensus for the Jocko cluster.
 type Raft interface {
-	Bootstrap(peers []*ClusterMember, broker Broker, leaderCh chan<- bool) (err error)
+	Bootstrap(peers []*ClusterMember, commandCh chan<- RaftCommand, leaderCh chan<- bool) (err error)
 	Apply(cmd RaftCommand) error
 	IsLeader() bool
 	LeaderID() string
@@ -180,8 +180,6 @@ type Broker interface {
 	Cluster() []*ClusterMember
 	TopicPartitions(topic string) ([]*Partition, error)
 	IsLeaderOfPartition(topic string, id int32, leaderID int32) bool
-
-	Apply(c RaftCommand)
 }
 
 // ClusterMember is used as a wrapper around a broker's info and a

--- a/raft/fsm.go
+++ b/raft/fsm.go
@@ -1,0 +1,43 @@
+package raft
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/hashicorp/raft"
+	"github.com/pkg/errors"
+	"github.com/travisjeffery/jocko"
+)
+
+type fsm struct {
+	//commandCh chan<- jocko.RaftCommand
+	broker jocko.Broker
+}
+
+func (s *fsm) Restore(rc io.ReadCloser) error {
+	return nil
+}
+
+type FSMSnapshot struct {
+}
+
+func (f *FSMSnapshot) Persist(sink raft.SnapshotSink) error {
+	return nil
+}
+
+func (f *FSMSnapshot) Release() {}
+
+func (s *fsm) Snapshot() (raft.FSMSnapshot, error) {
+	return &FSMSnapshot{}, nil
+}
+
+// Apply raft command as fsm
+func (s *fsm) Apply(l *raft.Log) interface{} {
+	var c jocko.RaftCommand
+	if err := json.Unmarshal(l.Data, &c); err != nil {
+		panic(errors.Wrap(err, "json unmarshal failed"))
+	}
+	//s.commandCh <- c
+	s.broker.Apply(c)
+	return nil
+}

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -45,7 +45,7 @@ func New(opts ...OptionFn) (*Raft, error) {
 
 // Bootstrap the Raft agent using fsm and connect to peers
 // Updates to leadership are returned on leaderCh channel
-func (b *Raft) Bootstrap(peers []*jocko.ClusterMember, fsm raft.FSM, leaderCh chan<- bool) (err error) {
+func (b *Raft) Bootstrap(peers []*jocko.ClusterMember, broker jocko.Broker, leaderCh chan<- bool) (err error) {
 	b.transport, err = raft.NewTCPTransport(b.addr, nil, 3, timeout, os.Stderr)
 	if err != nil {
 		return errors.Wrap(err, "tcp transport failed")
@@ -79,6 +79,8 @@ func (b *Raft) Bootstrap(peers []*jocko.ClusterMember, fsm raft.FSM, leaderCh ch
 
 	b.config.NotifyCh = leaderCh
 	b.config.StartAsLeader = !b.devDisableBootstrap
+
+	fsm := &fsm{broker: broker}
 
 	raft, err := raft.NewRaft(b.config, fsm, boltStore, boltStore, snapshots, raftPeers, b.transport)
 	if err != nil {


### PR DESCRIPTION
Part 2 of Issue #22 
@travisjeffery Made the changes suggested in PR #25 

Change set: Added wrapper over serf.MemberStatus and raft.FSM to cleanly hide hashicorp raft and serf from jocko behind interfaces

Next steps: add/edit tests
Will open a new issue for this