### PR TITLE
Move leadership from broker to raft

### DIFF
--- a/broker/fsm.go
+++ b/broker/fsm.go
@@ -27,10 +27,10 @@ func (s *Broker) raftApply(cmd jocko.RaftCmdType, data interface{}) error {
 	return s.raft.Apply(c)
 }
 
-func (s *Broker) handleRaftCommmands() {
+func (s *Broker) handleRaftCommmands(commandCh <-chan jocko.RaftCommand) {
 	for {
 		select {
-		case cmd := <-s.commandCh:
+		case cmd := <-commandCh:
 			s.apply(cmd)
 		case <-s.shutdownCh:
 			return

--- a/jocko.go
+++ b/jocko.go
@@ -146,7 +146,7 @@ type Serf interface {
 	Member(memberID int32) *ClusterMember
 	Join(addrs ...string) (int, error)
 	Shutdown() error
-	Addr() string
+	ID() int32
 }
 
 type RaftCmdType int
@@ -159,13 +159,10 @@ type RaftCommand struct {
 // Raft is the interface that wraps Raft's methods and is used to
 // manage consensus for the Jocko cluster.
 type Raft interface {
-	Bootstrap(peers []*ClusterMember, commandCh chan<- RaftCommand, leaderCh chan<- bool) (err error)
+	Bootstrap(serf Serf, serfEventCh <-chan *ClusterMember, commandCh chan<- RaftCommand) error
 	Apply(cmd RaftCommand) error
 	IsLeader() bool
 	LeaderID() string
-	WaitForBarrier() error
-	AddPeer(addr string) error
-	RemovePeer(addr string) error
 	Shutdown() error
 	Addr() string
 }


### PR DESCRIPTION
Changes:
- moved leader.go from broker package to raft package to finish the separation between broker and raft

Next steps:
- add raft test (mock out serf)
- add broker tests (mock out serf and raft)
- modify server tests (mock out broker)