### PR TITLE
Stop segments leaking in cleaner

### DIFF
--- a/commitlog/cleaner.go
+++ b/commitlog/cleaner.go
@@ -28,16 +28,11 @@ func (c *DeleteCleaner) Clean(segments []*Segment) ([]*Segment, error) {
 			s := segments[i]
 			totalBytes += s.Position
 			if totalBytes > c.Retention.Bytes {
-				break
-			}
-			cleanedSegments = append([]*Segment{s}, cleanedSegments...)
-		}
-		if i > -1 {
-			for ; i != 0; i-- {
-				s := segments[i]
 				if err := s.Delete(); err != nil {
 					return nil, err
 				}
+			} else {
+				cleanedSegments = append([]*Segment{s}, cleanedSegments...)
 			}
 		}
 	}

--- a/commitlog/index.go
+++ b/commitlog/index.go
@@ -151,10 +151,10 @@ func (idx *index) Sync() error {
 
 func (idx *index) Close() (err error) {
 	if err = idx.Sync(); err != nil {
-		return
+		return err
 	}
 	if err = idx.file.Truncate(idx.position); err != nil {
-		return
+		return err
 	}
 	return idx.file.Close()
 }


### PR DESCRIPTION
Segments were leaking - leading to file handles not being closed down properly. So benchmarks ran out of file handles. 

