### PR TITLE
Solves index out of range

### DIFF
--- a/protocol/api_key.go
+++ b/protocol/api_key.go
@@ -2,25 +2,25 @@ package protocol
 
 // Protocol API keys. See: https://kafka.apache.org/protocol#protocol_api_keys
 const (
-	ProduceKey = iota
-	FetchKey
-	OffsetsKey
-	MetadataKey
-	LeaderAndISRKey
-	StopReplicaKey
-	UpdateMetadataKey
-	ControlledShutdownKey
-	OffsetCommitKey
-	OffsetFetchKey
-	GroupCoordinatorKey
-	JoinGroupKey
-	HeartbeatKey
-	LeaveGroupKey
-	SyncGroupKey
-	DescribeGroupsKey
-	ListGroupsKey
-	SaslHandshakeKey
-	APIVersionsKey
-	CreateTopicsKey
-	DeleteTopicsKey
+	ProduceKey            = iota // 0
+	FetchKey                     // 1
+	OffsetsKey                   // 2
+	MetadataKey                  // 3
+	LeaderAndISRKey              // 4
+	StopReplicaKey               // 5
+	UpdateMetadataKey            // 6
+	ControlledShutdownKey        // 7
+	OffsetCommitKey              // 8
+	OffsetFetchKey               // 9
+	GroupCoordinatorKey          // 10
+	JoinGroupKey                 // 11
+	HeartbeatKey                 // 12
+	LeaveGroupKey                // 13
+	SyncGroupKey                 // 14
+	DescribeGroupsKey            // 15
+	ListGroupsKey                // 16
+	SaslHandshakeKey             // 17
+	APIVersionsKey               // 18
+	CreateTopicsKey              // 19
+	DeleteTopicsKey              // 20
 )

--- a/protocol/api_versions_requests.go
+++ b/protocol/api_versions_requests.go
@@ -1,0 +1,19 @@
+package protocol
+
+type APIVersionsRequest struct{}
+
+func (c *APIVersionsRequest) Encode(_ PacketEncoder) error {
+	return nil
+}
+
+func (c *APIVersionsRequest) Decode(_ PacketDecoder) error {
+	return nil
+}
+
+func (c *APIVersionsRequest) Key() int16 {
+	return APIVersionsKey
+}
+
+func (c *APIVersionsRequest) Version() int16 {
+	return 0
+}

--- a/protocol/api_versions_response.go
+++ b/protocol/api_versions_response.go
@@ -1,0 +1,57 @@
+package protocol
+
+type APIVersionsResponse struct {
+	APIVersions []APIVersion
+	ErrorCode   int16
+}
+
+type APIVersion struct {
+	APIKey     int16
+	MinVersion int16
+	MaxVersion int16
+}
+
+func (c *APIVersionsResponse) Encode(e PacketEncoder) error {
+	e.PutInt16(c.ErrorCode)
+
+	if err := e.PutArrayLength(len(c.APIVersions)); err != nil {
+		return err
+	}
+	for _, av := range c.APIVersions {
+		e.PutInt16(av.APIKey)
+		e.PutInt16(av.MinVersion)
+		e.PutInt16(av.MaxVersion)
+	}
+	return nil
+}
+
+func (c *APIVersionsResponse) Decode(d PacketDecoder) error {
+	l, err := d.ArrayLength()
+	if err != nil {
+		return err
+	}
+	c.APIVersions = make([]APIVersion, l)
+	for i := range c.APIVersions {
+		key, err := d.Int16()
+		if err != nil {
+			return err
+		}
+
+		minVersion, err := d.Int16()
+		if err != nil {
+			return err
+		}
+
+		maxVersion, err := d.Int16()
+		if err != nil {
+			return err
+		}
+
+		c.APIVersions[i] = APIVersion{
+			APIKey:     key,
+			MinVersion: minVersion,
+			MaxVersion: maxVersion,
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This change is a pragmatic solution to get kafkacat work. It would be more sophisticated to add a versioned API.

- Added APIVersions handler
- Solved bug in SetupIndex function that prevents the index to be set up

Relates to #40 and #37

```
~$ kafkacat  -P -b 127.0.0.1:9092 -L -t test2
Metadata for test2 (from broker 0: 127.0.0.1:9092/0):
 1 brokers:
  broker 0 at 127.0.0.1:9092
 1 topics:
  topic "test2" with 5 partitions:
    partition 0, leader 0, replicas: , isrs: 
    partition 1, leader 0, replicas: , isrs: 
    partition 2, leader 0, replicas: , isrs: 
    partition 3, leader 0, replicas: , isrs: 
    partition 4, leader 0, replicas: , isrs: 
```