### PR TITLE
Add testing setup.

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -48,12 +48,12 @@ func New(id int32, opts ...BrokerFn) (*Broker, error) {
 		o(b)
 	}
 
-	port, err := addrPort(b.brokerAddr)
+	_, port, err := jocko.SplitHostPort(b.brokerAddr)
 	if err != nil {
 		return nil, err
 	}
 
-	raftPort, err := addrPort(b.raft.Addr())
+	_, raftPort, err := jocko.SplitHostPort(b.raft.Addr())
 	if err != nil {
 		return nil, err
 	}

--- a/broker/broker_test.go
+++ b/broker/broker_test.go
@@ -1,0 +1,30 @@
+package broker_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/travisjeffery/jocko/broker"
+	"github.com/travisjeffery/jocko/testutil"
+)
+
+func TestBrokerNew(t *testing.T) {
+	l := testutil.NewTempDirList()
+	defer l.Cleanup()
+
+	t.Run("returns Broker instance", func(t *testing.T) {
+		assert.IsType(t, &broker.Broker{}, testutil.NewTestBroker(t, 0, l))
+	})
+
+	t.Run("yields instance to BrokerFns", func(t *testing.T) {
+		opt0 := func(b *broker.Broker) {
+			assert.IsType(t, &broker.Broker{}, b)
+		}
+
+		opt1 := func(b *broker.Broker) {
+			assert.IsType(t, &broker.Broker{}, b)
+		}
+
+		testutil.NewTestBroker(t, 0, l, opt0, opt1)
+	})
+}

--- a/broker/util.go
+++ b/broker/util.go
@@ -2,8 +2,6 @@ package broker
 
 import (
 	"encoding/json"
-	"net"
-	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -48,19 +46,6 @@ func (s *Broker) WaitForLeader(timeout time.Duration) (string, error) {
 		}
 	}
 }*/
-
-func addrPort(addr string) (int, error) {
-	_, strPort, err := net.SplitHostPort(addr)
-	if err != nil {
-		return 0, err
-	}
-
-	port, err := strconv.Atoi(strPort)
-	if err != nil {
-		return 0, err
-	}
-	return port, nil
-}
 
 func unmarshalData(data *json.RawMessage, p interface{}) error {
 	b, err := data.MarshalJSON()

--- a/raft/raft_test.go
+++ b/raft/raft_test.go
@@ -1,0 +1,30 @@
+package raft_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/travisjeffery/jocko/raft"
+	"github.com/travisjeffery/jocko/testutil"
+)
+
+func TestNew(t *testing.T) {
+	l := testutil.NewTempDirList()
+	defer l.Cleanup()
+
+	t.Run("returns Raft instance", func(t *testing.T) {
+		assert.IsType(t, &raft.Raft{}, testutil.NewTestRaft(t, l))
+	})
+
+	t.Run("yields instance to OptionFns", func(t *testing.T) {
+		opt1 := func(r *raft.Raft) {
+			assert.IsType(t, &raft.Raft{}, r)
+		}
+
+		opt2 := func(r *raft.Raft) {
+			assert.IsType(t, &raft.Raft{}, r)
+		}
+
+		testutil.NewTestRaft(t, l, opt1, opt2)
+	})
+}

--- a/serf/export_test.go
+++ b/serf/export_test.go
@@ -1,0 +1,5 @@
+package serf
+
+func (s *Serf) GetAddr() string {
+	return s.addr
+}

--- a/testutil/broker.go
+++ b/testutil/broker.go
@@ -1,0 +1,25 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/travisjeffery/jocko/broker"
+)
+
+// NewTestBroker creates a new (non-bootstrapped) Broker instance.
+// An entry will be added to TempDirList on success. It is the user's
+// responsibility to call Cleanup() on the TempDirList after use.
+func NewTestBroker(t *testing.T, id int32, l *TempDirList, opts ...broker.BrokerFn) *broker.Broker {
+	opts = append(opts,
+		broker.LogDir(l.NewTempDir(t)),
+		broker.Addr(NewTestAddr(t)),
+		broker.Logger(NewTestLogger()),
+		broker.Serf(NewTestSerf(t)),
+		broker.Raft(NewTestRaft(t, l)),
+	)
+
+	b, err := broker.New(id, opts...)
+	assert.NoError(t, err)
+	return b
+}

--- a/testutil/log.go
+++ b/testutil/log.go
@@ -1,0 +1,15 @@
+package testutil
+
+import (
+	"github.com/travisjeffery/simplelog"
+	"os"
+)
+
+// NewTestLogger creates a standard logger for test use.
+func NewTestLogger() *simplelog.Logger {
+	return simplelog.New(
+		os.Stdout,
+		simplelog.INFO,
+		"jocko/test",
+	)
+}

--- a/testutil/net.go
+++ b/testutil/net.go
@@ -1,0 +1,27 @@
+package testutil
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/travisjeffery/jocko"
+)
+
+// NewTestAddr finds a free port on localhost from the OS and returns
+// an address string.
+func NewTestAddr(t *testing.T) string {
+	tcp, err := net.Listen("tcp", "localhost:0")
+	assert.NoError(t, err)
+	defer tcp.Close()
+
+	return tcp.Addr().String()
+}
+
+// NewTestPort finds and returns a free port on localhost from the OS.
+func NewTestPort(t *testing.T) int {
+	_, port, err := jocko.SplitHostPort(NewTestAddr(t))
+	assert.NoError(t, err)
+
+	return port
+}

--- a/testutil/raft.go
+++ b/testutil/raft.go
@@ -1,0 +1,23 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/travisjeffery/jocko/raft"
+)
+
+// NewTestRaft creates a new (non-bootstrapped) Raft instance.
+// An entry will be added to the TempDirList on success. It is the user's
+// responsibility to call Cleanup() on the TempDirList after use.
+func NewTestRaft(t *testing.T, l *TempDirList, opts ...raft.OptionFn) *raft.Raft {
+	opts = append(opts,
+		raft.Logger(NewTestLogger()),
+		raft.DataDir(l.NewTempDir(t)),
+		raft.Addr(NewTestAddr(t)),
+	)
+
+	s, err := raft.New(opts...)
+	assert.NoError(t, err)
+	return s
+}

--- a/testutil/serf.go
+++ b/testutil/serf.go
@@ -1,0 +1,56 @@
+package testutil
+
+import (
+	"testing"
+
+	hashiserf "github.com/hashicorp/serf/serf"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/travisjeffery/jocko"
+	"github.com/travisjeffery/jocko/serf"
+)
+
+// NewTestSerf creates a new (non-bootstrapped) Serf instance.
+func NewTestSerf(t *testing.T, opts ...serf.OptionFn) *serf.Serf {
+	opts = append(opts,
+		serf.Logger(NewTestLogger()),
+		serf.Addr(NewTestAddr(t)),
+	)
+
+	s, err := serf.New(opts...)
+	assert.NoError(t, err)
+	return s
+}
+
+// NewTestSerfConfig creates a new jocko.ClusterMember and
+// hashicorp.serf.Config to expose the internals of Serf initialization.
+func NewTestSerfConfig(t *testing.T, s *serf.Serf) (*jocko.ClusterMember, *hashiserf.Config) {
+	// TODO: do these need unique IDs?
+	m := NewTestClusterMember(t, 0)
+
+	c, err := s.Configure(m)
+	assert.NoError(t, err)
+
+	return m, c
+}
+
+// NewTestClusterMember creates a new jocko.ClusterMember with free ports.
+func NewTestClusterMember(t *testing.T, id int32) *jocko.ClusterMember {
+	return &jocko.ClusterMember{
+		ID:       id,
+		Port:     NewTestPort(t),
+		RaftPort: NewTestPort(t),
+	}
+}
+
+// NewBootstrappedTestSerf creates a new (bootstrapped) Serf instance.
+func NewBootstrappedTestSerf(t *testing.T, id int32) *serf.Serf {
+	s := NewTestSerf(t)
+	m := NewTestClusterMember(t, id)
+	ch := make(chan *jocko.ClusterMember, 32)
+
+	err := s.Bootstrap(m, ch)
+	assert.NoError(t, err)
+
+	return s
+}

--- a/testutil/tempdirlist.go
+++ b/testutil/tempdirlist.go
@@ -1,0 +1,42 @@
+package testutil
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TempDirList is a container for acquiring and removing temporary
+// directories from the OS.
+type TempDirList struct {
+	tempDirs []string
+}
+
+// NewTempDirList creates a new TempDirList.
+func NewTempDirList() *TempDirList {
+	return &TempDirList{}
+}
+
+// NewTempDir acquires a new temporary directory from the OS and
+// returns a string representing it's location.
+func (l *TempDirList) NewTempDir(t *testing.T) string {
+	tmpDir, err := ioutil.TempDir("/tmp", "")
+	assert.NoError(t, err)
+
+	l.tempDirs = append(l.tempDirs, tmpDir)
+
+	return tmpDir
+}
+
+// Cleanup removes all temporary directories that have been acquired
+// from the OS.
+func (l *TempDirList) Cleanup() {
+	for _, dir := range l.tempDirs {
+		os.RemoveAll(dir)
+	}
+
+	// clear tempDirs
+	l.tempDirs = l.tempDirs[:0]
+}

--- a/util.go
+++ b/util.go
@@ -1,0 +1,20 @@
+package jocko
+
+import (
+	"net"
+	"strconv"
+)
+
+func SplitHostPort(addr string) (string, int, error) {
+	addr, strPort, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", 0, err
+	}
+
+	port, err := strconv.Atoi(strPort)
+	if err != nil {
+		return "", 0, err
+	}
+
+	return addr, port, nil
+}


### PR DESCRIPTION
# Add Testing Setup

The testing coverage at this point is weak and this *doesn't* forward that much. What this commit *does*:

1. Moves common testing things into helpers (see `testutil/*.go`)
1. Adds a starter test (probably not ultimately necessary) in {broker,serf,raft}_test.go
1. Moves a common `net.SplitHostPort` function into a `util.go` file in the main `jocko` package. We probably have other shared logic, right?

I've made on transgression. I moved some stuff out of `serf.New` into a new `serf.Serf.Configure` method. Shouldn't have changed any functionality.