### PR TITLE
Update readme and Dockerfile with Prometheus address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ RUN GOOS=linux GOARCH=amd64 make deps build
 
 FROM alpine:latest
 COPY --from=0 /go/src/github.com/travisjeffery/jocko/jocko /usr/local/bin/jocko
-EXPOSE 9092 9093 9094
+EXPOSE 9092 9093 9094 9095
 VOLUME "/tmp/jocko"
 CMD ["jocko"]

--- a/examples/cluster/README.md
+++ b/examples/cluster/README.md
@@ -19,6 +19,7 @@ $ ./jocko broker \
           --broker-addr=127.0.0.1:9001 \
           --raft-addr=127.0.0.1:9002 \
           --serf-addr=127.0.0.1:9003 \
+          --prometheus-addr=127.0.0.1:9004 \
           --id=1
 
 $ ./jocko broker \
@@ -27,6 +28,7 @@ $ ./jocko broker \
           --broker-addr=127.0.0.1:9101 \
           --raft-addr=127.0.0.1:9102 \
           --serf-addr=127.0.0.1:9103 \
+          --prometheus-addr=127.0.0.1:9104 \
           --serf-members=127.0.0.1:9003 \
           --id=2
 
@@ -36,6 +38,7 @@ $ ./jocko broker \
           --broker-addr=127.0.0.1:9201 \
           --raft-addr=127.0.0.1:9202 \
           --serf-addr=127.0.0.1:9203 \
+          --prometheus-addr=127.0.0.1:9204 \
           --serf-members=127.0.0.1:9003 \
           --id=3
 ```


### PR DESCRIPTION
After adding Prometheus instrumentation, the docs weren't updated. Current example with 3 brokers won't work because it will bind on the default port 3 times, so I updated this. Also exposed Prometheus default port in the Dockerfile.