### PR TITLE
Fixed Missing Metrics Which Causes SegFault

### DIFF
--- a/cmd/jocko/main.go
+++ b/cmd/jocko/main.go
@@ -10,6 +10,7 @@ import (
 	gracefully "github.com/tj/go-gracefully"
 	"github.com/travisjeffery/jocko/broker"
 	"github.com/travisjeffery/jocko/log"
+	"github.com/travisjeffery/jocko/prometheus"
 	"github.com/travisjeffery/jocko/protocol"
 	"github.com/travisjeffery/jocko/raft"
 	"github.com/travisjeffery/jocko/serf"
@@ -107,7 +108,7 @@ func cmdBrokers() int {
 		os.Exit(1)
 	}
 
-	srv := server.New(*brokerCmdConfig.ServerConfig, broker, nil, logger)
+	srv := server.New(*brokerCmdConfig.ServerConfig, broker, prometheus.NewMetrics(), logger)
 	if err := srv.Start(context.Background()); err != nil {
 		fmt.Fprintf(os.Stderr, "error starting server: %v\n", err)
 		os.Exit(1)


### PR DESCRIPTION
The `nil` metrics causes a segfault when running `jocko broker` and a request comes in