### PR TITLE
Assign Missing Serf Parameters

### DIFF
--- a/cmd/jocko/main.go
+++ b/cmd/jocko/main.go
@@ -89,6 +89,10 @@ func cmdBrokers() int {
 		log.String("raft addr", brokerCmdConfig.RaftConfig.Addr),
 	)
 
+	brokerCmdConfig.SerfConfig.BrokerAddr = brokerCmdConfig.ServerConfig.BrokerAddr
+	brokerCmdConfig.SerfConfig.HTTPAddr = brokerCmdConfig.ServerConfig.HTTPAddr
+	brokerCmdConfig.SerfConfig.RaftAddr = brokerCmdConfig.RaftConfig.Addr
+
 	serf, err := serf.New(*brokerCmdConfig.SerfConfig, logger)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error starting serf: %v\n", err)


### PR DESCRIPTION
Without this assignment the local broker is not added as a cluster member which causes metadata requests to fail using `rdkafka` (since there should be at least 1 broker)