### PR TITLE
Cleanup cluster example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vendor/*
 *.index
 NOTES.txt
 .dir-locals.el
+jocko

--- a/cmd/jocko/main.go
+++ b/cmd/jocko/main.go
@@ -25,10 +25,8 @@ var (
 	}
 
 	brokerCfg = struct {
-		ID      int32
-		DataDir string
-		Broker  *config.Config
-		Server  *server.Config
+		Broker *config.Config
+		Server *server.Config
 	}{
 		Broker: config.DefaultConfig(),
 		Server: &server.Config{},
@@ -45,13 +43,13 @@ var (
 func init() {
 	brokerCmd := &cobra.Command{Use: "broker", Short: "Run a Jocko broker", Run: run}
 	brokerCmd.Flags().StringVar(&brokerCfg.Broker.RaftAddr, "raft-addr", "127.0.0.1:9093", "Address for Raft to bind and advertise on")
-	brokerCmd.Flags().StringVar(&brokerCfg.DataDir, "data-dir", "/tmp/jocko", "A comma separated list of directories under which to store log files")
+	brokerCmd.Flags().StringVar(&brokerCfg.Broker.DataDir, "data-dir", "/tmp/jocko", "A comma separated list of directories under which to store log files")
 	brokerCmd.Flags().StringVar(&brokerCfg.Broker.Addr, "broker-addr", "0.0.0.0:9092", "Address for broker to bind on")
 	brokerCmd.Flags().StringVar(&brokerCfg.Broker.SerfLANConfig.MemberlistConfig.BindAddr, "serf-addr", "0.0.0.0:9094", "Address for Serf to bind on") // TODO: can set addr alone or need to set bind port separately?
 	brokerCmd.Flags().StringVar(&brokerCfg.Server.HTTPAddr, "http-addr", ":9095", "Address for HTTP handlers to serve Prometheus metrics on")
 	brokerCmd.Flags().StringSliceVar(&brokerCfg.Broker.StartJoinAddrsLAN, "join", nil, "Address of an broker serf to join at start time. Can be specified multiple times.")
 	brokerCmd.Flags().StringSliceVar(&brokerCfg.Broker.StartJoinAddrsWAN, "join-wan", nil, "Address of an broker serf to join -wan at start time. Can be specified multiple times.")
-	brokerCmd.Flags().Int32Var(&brokerCfg.ID, "id", 0, "Broker ID")
+	brokerCmd.Flags().Int32Var(&brokerCfg.Broker.ID, "id", 0, "Broker ID")
 
 	topicCmd := &cobra.Command{Use: "topic", Short: "Manage topics"}
 	createTopicCmd := &cobra.Command{Use: "create", Short: "Create a topic", Run: createTopic}
@@ -68,7 +66,7 @@ func init() {
 func run(cmd *cobra.Command, args []string) {
 	var err error
 	logger := log.New().With(
-		log.Int32("id", brokerCfg.ID),
+		log.Int32("id", brokerCfg.Broker.ID),
 		log.String("broker addr", brokerCfg.Server.BrokerAddr),
 		log.String("http addr", brokerCfg.Server.HTTPAddr),
 		log.String("serf addr", brokerCfg.Broker.SerfLANConfig.MemberlistConfig.BindAddr),

--- a/examples/cluster/README.md
+++ b/examples/cluster/README.md
@@ -14,31 +14,28 @@ $ go build
 
 ```bash
 $ ./jocko broker \
-          --debug \
-          --log-dir="/tmp/jocko0" \
+          --data-dir="/tmp/jocko0" \
           --broker-addr=127.0.0.1:9001 \
           --raft-addr=127.0.0.1:9002 \
           --serf-addr=127.0.0.1:9003 \
-          --prometheus-addr=127.0.0.1:9004 \
+          --http-addr=127.0.0.1:9004 \
           --id=1
 
 $ ./jocko broker \
-          --debug \
-          --log-dir="/tmp/jocko1" \
+          --data-dir="/tmp/jocko1" \
           --broker-addr=127.0.0.1:9101 \
           --raft-addr=127.0.0.1:9102 \
           --serf-addr=127.0.0.1:9103 \
-          --prometheus-addr=127.0.0.1:9104 \
+          --http-addr=127.0.0.1:9104 \
           --serf-members=127.0.0.1:9003 \
           --id=2
 
 $ ./jocko broker \
-          --debug \
-          --log-dir="/tmp/jocko2" \
+          --data-dir="/tmp/jocko2" \
           --broker-addr=127.0.0.1:9201 \
           --raft-addr=127.0.0.1:9202 \
           --serf-addr=127.0.0.1:9203 \
-          --prometheus-addr=127.0.0.1:9204 \
+          --http-addr=127.0.0.1:9204 \
           --serf-members=127.0.0.1:9003 \
           --id=3
 ```


### PR DESCRIPTION
While trying to reproduce https://github.com/travisjeffery/jocko/issues/20 I've noticed that:
- the cluster example is using outdated config flags - I found replacement for `log-dir` and `prometheus-addr` to be `data-dir` and `http-addr`, but I couldn't find replacement for `debug` so its usage is just removed (maybe `DevMode` is planned replacement, but that one is not configurable through CLI at the moment and it doesn't change zap logger so probably should be in separate commit)
- `broker-id` and `data-dir` config flags were configuring config struct properties which weren't actually used, there were duplicate struct properties which were used but not configurable throgh CLI
- `jocko` binary produced from both `make build` and by following cluster example is not gitignored so could be by accident committed to version control

This PR fixes the 3 mentioned issues in 3 separate commits.