### PR TITLE
example: fix Sarama example

### DIFF
--- a/_examples/sarama/main.go
+++ b/_examples/sarama/main.go
@@ -92,10 +92,10 @@ func main() {
 			fmt.Printf("msg partition [%d] offset [%d]\n", msg.Partition, msg.Offset)
 			check := pmap[partitionID][i]
 			if string(msg.Value) != check.message {
-				log.Fatal.Printf("msg values not equal: partition: %d: offset: %d", msg.Partition, msg.Offset)
+				log.Debug.Fatalf("msg values not equal: partition: %d: offset: %d", msg.Partition, msg.Offset)
 			}
 			if msg.Offset != check.offset {
-				log.Fatal.Printf("msg offsets not equal: partition: %d: offset: %d", msg.Partition, msg.Offset)
+				log.Debug.Fatalf("msg offsets not equal: partition: %d: offset: %d", msg.Partition, msg.Offset)
 			}
 			log.Info.Printf("msg is ok: partition: %d: offset: %d", msg.Partition, msg.Offset)
 			i++
@@ -117,7 +117,7 @@ func main() {
 }
 
 func setup() (*jocko.Server, func()) {
-	c, cancel := jocko.NewTestServer(&testing.T{}, func(cfg *config.Config) {
+	c, dataDir := jocko.NewTestServer(&testing.T{}, func(cfg *config.Config) {
 		cfg.Bootstrap = true
 		cfg.BootstrapExpect = 1
 		cfg.StartAsLeader = true
@@ -152,8 +152,8 @@ func setup() (*jocko.Server, func()) {
 	}
 
 	return c, func() {
-		cancel()
 		c.Shutdown()
+		os.RemoveAll(dataDir)
 		os.RemoveAll(logDir)
 	}
 }


### PR DESCRIPTION
Sarama example did not run correctly, notably because the second value
returned by NewTestServer is not a cancel function but a string with
the directory containing Kafka data.