### PR TITLE
Implement Kafka consumer group support

### DIFF
--- a/jocko/broker.go
+++ b/jocko/broker.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -638,30 +639,42 @@ func (b *Broker) handleJoinGroup(ctx *Context, r *protocol.JoinGroupRequest) *pr
 			GenerationID: 1,
 		}
 	}
-	if group.Members == nil {
-		group.Members = make(map[string]structs.Member)
-	}
-	if group.Offsets == nil {
-		group.Offsets = make(map[string]map[int32]structs.Offset)
-	}
+	normalizeGroup(group)
+
 	if r.MemberID == "" {
-		// for group member IDs -- can replace with something else
-		r.MemberID = ctx.Header().ClientID + "-" + uuid.NewV1().String()
+		r.MemberID = stableMemberID(ctx)
 	}
-	group.Members[r.MemberID] = structs.Member{
-		ID:       r.MemberID,
-		Metadata: selectedGroupProtocolMetadata(r.GroupProtocols),
+	_, knownMember := group.Members[r.MemberID]
+	if !knownMember && len(group.Members) > 0 {
+		startGroupRebalance(group)
 	}
+	member := group.Members[r.MemberID]
+	member.ID = r.MemberID
+	member.Metadata = selectedGroupProtocolMetadata(r.GroupProtocols)
+	member.JoinedGeneration = group.GenerationID
+	group.Members[r.MemberID] = member
 	if group.LeaderID == "" {
-		group.LeaderID = r.MemberID
+		group.LeaderID = firstGroupMemberID(group)
 	}
-	group.State = structs.GroupStateCompletingRebalance
+	if allMembersJoined(group) {
+		group.State = structs.GroupStateCompletingRebalance
+	} else {
+		group.State = structs.GroupStatePreparingRebalance
+	}
 	_, err = b.raftApply(structs.RegisterGroupRequestType, structs.RegisterGroupRequest{
 		Group: *group,
 	})
 	if err != nil {
 		log.Error.Printf("broker/%d: register group error: %s", b.config.ID, err)
 		res.ErrorCode = protocol.ErrUnknown.Code()
+		return res
+	}
+	if group.State == structs.GroupStatePreparingRebalance {
+		res.ErrorCode = protocol.ErrRebalanceInProgress.Code()
+		res.GenerationID = group.GenerationID
+		res.GroupProtocol = selectedGroupProtocolName(r.GroupProtocols)
+		res.LeaderID = group.LeaderID
+		res.MemberID = r.MemberID
 		return res
 	}
 
@@ -679,6 +692,68 @@ func (b *Broker) handleJoinGroup(ctx *Context, r *protocol.JoinGroupRequest) *pr
 	}
 
 	return res
+}
+
+func stableMemberID(ctx *Context) string {
+	if ctx != nil && ctx.Header() != nil && ctx.Header().ClientID != "" {
+		return ctx.Header().ClientID
+	}
+	return uuid.NewV1().String()
+}
+
+func normalizeGroup(group *structs.Group) {
+	if group.Members == nil {
+		group.Members = make(map[string]structs.Member)
+	}
+	if group.Offsets == nil {
+		group.Offsets = make(map[string]map[int32]structs.Offset)
+	}
+	if group.GenerationID == 0 {
+		group.GenerationID = 1
+	}
+	if len(group.Members) == 0 {
+		group.State = structs.GroupStateEmpty
+		group.LeaderID = ""
+		return
+	}
+	if group.LeaderID == "" {
+		group.LeaderID = firstGroupMemberID(group)
+	}
+}
+
+func firstGroupMemberID(group *structs.Group) string {
+	memberIDs := make([]string, 0, len(group.Members))
+	for memberID := range group.Members {
+		memberIDs = append(memberIDs, memberID)
+	}
+	sort.Strings(memberIDs)
+	if len(memberIDs) == 0 {
+		return ""
+	}
+	return memberIDs[0]
+}
+
+func startGroupRebalance(group *structs.Group) {
+	group.GenerationID++
+	group.State = structs.GroupStatePreparingRebalance
+	group.LeaderID = firstGroupMemberID(group)
+	for memberID, member := range group.Members {
+		member.Assignment = nil
+		member.JoinedGeneration = 0
+		group.Members[memberID] = member
+	}
+}
+
+func allMembersJoined(group *structs.Group) bool {
+	if len(group.Members) == 0 {
+		return false
+	}
+	for _, member := range group.Members {
+		if member.JoinedGeneration != group.GenerationID {
+			return false
+		}
+	}
+	return true
 }
 
 func selectedGroupProtocolName(protocols []*protocol.GroupProtocol) string {
@@ -714,6 +789,7 @@ func (b *Broker) handleLeaveGroup(ctx *Context, r *protocol.LeaveGroupRequest) *
 		res.ErrorCode = protocol.ErrInvalidGroupId.Code()
 		return res
 	}
+	normalizeGroup(group)
 	if _, ok := group.Members[r.MemberID]; !ok {
 		res.ErrorCode = protocol.ErrUnknownMemberId.Code()
 		return res
@@ -730,7 +806,7 @@ func (b *Broker) handleLeaveGroup(ctx *Context, r *protocol.LeaveGroupRequest) *
 	if len(group.Members) == 0 {
 		group.State = structs.GroupStateEmpty
 	} else {
-		group.State = structs.GroupStatePreparingRebalance
+		startGroupRebalance(group)
 	}
 
 	_, err = b.raftApply(structs.RegisterGroupRequestType, structs.RegisterGroupRequest{
@@ -761,6 +837,7 @@ func (b *Broker) handleSyncGroup(ctx *Context, r *protocol.SyncGroupRequest) *pr
 		res.ErrorCode = protocol.ErrInvalidGroupId.Code()
 		return res
 	}
+	normalizeGroup(group)
 	if _, ok := group.Members[r.MemberID]; !ok {
 		res.ErrorCode = protocol.ErrUnknownMemberId.Code()
 		return res
@@ -780,6 +857,10 @@ func (b *Broker) handleSyncGroup(ctx *Context, r *protocol.SyncGroupRequest) *pr
 
 	if group.LeaderID == r.MemberID {
 		// take the assignments from the leader and save them
+		for memberID, member := range group.Members {
+			member.Assignment = nil
+			group.Members[memberID] = member
+		}
 		for _, ga := range r.GroupAssignments {
 			if m, ok := group.Members[ga.MemberID]; ok {
 				m.Assignment = ga.MemberAssignment
@@ -799,6 +880,10 @@ func (b *Broker) handleSyncGroup(ctx *Context, r *protocol.SyncGroupRequest) *pr
 		}
 	}
 	if m, ok := group.Members[r.MemberID]; ok {
+		if group.State == structs.GroupStateCompletingRebalance && group.LeaderID != r.MemberID && len(m.Assignment) == 0 {
+			res.ErrorCode = protocol.ErrRebalanceInProgress.Code()
+			return res
+		}
 		res.MemberAssignment = m.Assignment
 	} else {
 		res.ErrorCode = protocol.ErrUnknownMemberId.Code()
@@ -824,8 +909,13 @@ func (b *Broker) handleHeartbeat(ctx *Context, r *protocol.HeartbeatRequest) *pr
 		res.ErrorCode = protocol.ErrInvalidGroupId.Code()
 		return res
 	}
+	normalizeGroup(group)
 	if _, ok := group.Members[r.MemberID]; !ok {
 		res.ErrorCode = protocol.ErrUnknownMemberId.Code()
+		return res
+	}
+	if group.State != structs.GroupStateStable {
+		res.ErrorCode = protocol.ErrRebalanceInProgress.Code()
 		return res
 	}
 	if r.GroupGenerationID != group.GenerationID {
@@ -864,6 +954,12 @@ func (b *Broker) handleFetch(ctx *Context, r *protocol.FetchRequest) *protocol.F
 				if replica.Log == nil {
 					return protocol.ErrReplicaNotAvailable
 				}
+				newestOffset := replica.Log.NewestOffset()
+				if p.FetchOffset >= newestOffset {
+					fpres.HighWatermark = newestOffset
+					fpres.RecordSet = []byte{}
+					return protocol.ErrNone
+				}
 				rdr, rdrErr := replica.Log.NewReader(p.FetchOffset, p.MaxBytes)
 				if rdrErr != nil {
 					log.Error.Printf("broker/%d: replica log read error: %s", b.config.ID, rdrErr)
@@ -884,7 +980,7 @@ func (b *Broker) handleFetch(ctx *Context, r *protocol.FetchRequest) *protocol.F
 						break
 					}
 				}
-				fpres.HighWatermark = replica.Log.NewestOffset() - 1
+				fpres.HighWatermark = newestOffset - 1
 				fpres.RecordSet = buf.Bytes()
 				return protocol.ErrNone
 			})
@@ -1513,7 +1609,6 @@ func (b *Broker) withTimeout(timeout time.Duration, fn func() protocol.Error) pr
 	}
 
 	c := make(chan protocol.Error, 1)
-	defer close(c)
 
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()

--- a/jocko/broker.go
+++ b/jocko/broker.go
@@ -631,19 +631,31 @@ func (b *Broker) handleJoinGroup(ctx *Context, r *protocol.JoinGroupRequest) *pr
 	if group == nil {
 		// group doesn't exist so let's create it
 		group = &structs.Group{
-			Group:       r.GroupID,
-			Coordinator: b.config.ID,
-			Members:     make(map[string]structs.Member),
+			Group:        r.GroupID,
+			Coordinator:  b.config.ID,
+			Members:      make(map[string]structs.Member),
+			Offsets:      make(map[string]map[int32]structs.Offset),
+			GenerationID: 1,
 		}
+	}
+	if group.Members == nil {
+		group.Members = make(map[string]structs.Member)
+	}
+	if group.Offsets == nil {
+		group.Offsets = make(map[string]map[int32]structs.Offset)
 	}
 	if r.MemberID == "" {
 		// for group member IDs -- can replace with something else
 		r.MemberID = ctx.Header().ClientID + "-" + uuid.NewV1().String()
-		group.Members[r.MemberID] = structs.Member{ID: r.MemberID}
+	}
+	group.Members[r.MemberID] = structs.Member{
+		ID:       r.MemberID,
+		Metadata: selectedGroupProtocolMetadata(r.GroupProtocols),
 	}
 	if group.LeaderID == "" {
 		group.LeaderID = r.MemberID
 	}
+	group.State = structs.GroupStateCompletingRebalance
 	_, err = b.raftApply(structs.RegisterGroupRequestType, structs.RegisterGroupRequest{
 		Group: *group,
 	})
@@ -653,7 +665,8 @@ func (b *Broker) handleJoinGroup(ctx *Context, r *protocol.JoinGroupRequest) *pr
 		return res
 	}
 
-	res.GenerationID = 0
+	res.GenerationID = group.GenerationID
+	res.GroupProtocol = selectedGroupProtocolName(r.GroupProtocols)
 	res.LeaderID = group.LeaderID
 	res.MemberID = r.MemberID
 
@@ -666,6 +679,20 @@ func (b *Broker) handleJoinGroup(ctx *Context, r *protocol.JoinGroupRequest) *pr
 	}
 
 	return res
+}
+
+func selectedGroupProtocolName(protocols []*protocol.GroupProtocol) string {
+	if len(protocols) == 0 {
+		return ""
+	}
+	return protocols[0].ProtocolName
+}
+
+func selectedGroupProtocolMetadata(protocols []*protocol.GroupProtocol) []byte {
+	if len(protocols) == 0 {
+		return nil
+	}
+	return protocols[0].ProtocolMetadata
 }
 
 func (b *Broker) handleLeaveGroup(ctx *Context, r *protocol.LeaveGroupRequest) *protocol.LeaveGroupResponse {
@@ -693,6 +720,18 @@ func (b *Broker) handleLeaveGroup(ctx *Context, r *protocol.LeaveGroupRequest) *
 	}
 
 	delete(group.Members, r.MemberID)
+	if group.LeaderID == r.MemberID {
+		group.LeaderID = ""
+		for memberID := range group.Members {
+			group.LeaderID = memberID
+			break
+		}
+	}
+	if len(group.Members) == 0 {
+		group.State = structs.GroupStateEmpty
+	} else {
+		group.State = structs.GroupStatePreparingRebalance
+	}
 
 	_, err = b.raftApply(structs.RegisterGroupRequestType, structs.RegisterGroupRequest{
 		Group: *group,
@@ -737,29 +776,6 @@ func (b *Broker) handleSyncGroup(ctx *Context, r *protocol.SyncGroupRequest) *pr
 	case structs.GroupStatePreparingRebalance:
 		res.ErrorCode = protocol.ErrRebalanceInProgress.Code()
 		return res
-	case structs.GroupStateCompletingRebalance:
-		// TODO: wait to get member in group
-
-		if group.LeaderID == r.MemberID {
-			// if is leader, attempt to persist state and transition to stable
-			var assignment []protocol.GroupAssignment
-			for _, ga := range r.GroupAssignments {
-				if _, ok := group.Members[ga.MemberID]; !ok {
-					// if member isn't set fill in with empty assignment
-					assignment = append(assignment, protocol.GroupAssignment{
-						MemberID:         ga.MemberID,
-						MemberAssignment: nil,
-					})
-				} else {
-					assignment = append(assignment, ga)
-				}
-
-				// save group
-			}
-		}
-	case structs.GroupStateStable:
-		// in stable, return current assignment
-
 	}
 
 	if group.LeaderID == r.MemberID {
@@ -767,10 +783,13 @@ func (b *Broker) handleSyncGroup(ctx *Context, r *protocol.SyncGroupRequest) *pr
 		for _, ga := range r.GroupAssignments {
 			if m, ok := group.Members[ga.MemberID]; ok {
 				m.Assignment = ga.MemberAssignment
+				group.Members[ga.MemberID] = m
 			} else {
-				panic("sync group: unknown member")
+				res.ErrorCode = protocol.ErrUnknownMemberId.Code()
+				return res
 			}
 		}
+		group.State = structs.GroupStateStable
 		_, err = b.raftApply(structs.RegisterGroupRequestType, structs.RegisterGroupRequest{
 			Group: *group,
 		})
@@ -778,13 +797,11 @@ func (b *Broker) handleSyncGroup(ctx *Context, r *protocol.SyncGroupRequest) *pr
 			res.ErrorCode = protocol.ErrUnknown.Code()
 			return res
 		}
+	}
+	if m, ok := group.Members[r.MemberID]; ok {
+		res.MemberAssignment = m.Assignment
 	} else {
-		// TODO: need to wait until leader sets assignments
-		if m, ok := group.Members[r.MemberID]; ok {
-			res.MemberAssignment = m.Assignment
-		} else {
-			panic(fmt.Errorf("sync group: unknown member: %s", r.MemberID))
-		}
+		res.ErrorCode = protocol.ErrUnknownMemberId.Code()
 	}
 
 	return res
@@ -807,7 +824,14 @@ func (b *Broker) handleHeartbeat(ctx *Context, r *protocol.HeartbeatRequest) *pr
 		res.ErrorCode = protocol.ErrInvalidGroupId.Code()
 		return res
 	}
-	// TODO: need to handle case when rebalance is in process
+	if _, ok := group.Members[r.MemberID]; !ok {
+		res.ErrorCode = protocol.ErrUnknownMemberId.Code()
+		return res
+	}
+	if r.GroupGenerationID != group.GenerationID {
+		res.ErrorCode = protocol.ErrIllegalGeneration.Code()
+		return res
+	}
 
 	res.ErrorCode = protocol.ErrNone.Code()
 
@@ -884,10 +908,6 @@ func (b *Broker) handleListGroups(ctx *Context, req *protocol.ListGroupsRequest)
 	res.APIVersion = req.Version()
 	state := b.fsm.State()
 
-	fmt.Println("list")
-	fmt.Println("list")
-	fmt.Println("list")
-
 	_, groups, err := state.GetGroups()
 	if err != nil {
 		res.ErrorCode = protocol.ErrUnknown.Code()
@@ -910,23 +930,22 @@ func (b *Broker) handleDescribeGroups(ctx *Context, req *protocol.DescribeGroups
 	res.APIVersion = req.Version()
 	state := b.fsm.State()
 
-	fmt.Println("describe")
-	fmt.Println("describe")
-	fmt.Println("describe")
-
 	for _, id := range req.GroupIDs {
-		group := protocol.Group{}
+		group := protocol.Group{GroupID: id, GroupMembers: make(map[string]*protocol.GroupMember)}
 		_, g, err := state.GetGroup(id)
 		if err != nil {
 			group.ErrorCode = protocol.ErrUnknown.Code()
-			group.GroupID = id
 			res.Groups = append(res.Groups, group)
 			return res
 		}
-		group.GroupID = id
-		group.State = "Stable"
+		if g == nil {
+			group.ErrorCode = protocol.ErrInvalidGroupId.Code()
+			res.Groups = append(res.Groups, group)
+			continue
+		}
+		group.State = groupStateString(g.State)
 		group.ProtocolType = "consumer"
-		group.Protocol = "consumer"
+		group.Protocol = "range"
 		for id, member := range g.Members {
 			group.GroupMembers[id] = &protocol.GroupMember{
 				ClientID: member.ID,
@@ -936,11 +955,28 @@ func (b *Broker) handleDescribeGroups(ctx *Context, req *protocol.DescribeGroups
 				GroupMemberAssignment: member.Assignment,
 			}
 		}
-		res.Groups = append(res.Groups)
+		res.Groups = append(res.Groups, group)
 
 	}
 
 	return res
+}
+
+func groupStateString(state structs.GroupState) string {
+	switch state {
+	case structs.GroupStatePreparingRebalance:
+		return "PreparingRebalance"
+	case structs.GroupStateCompletingRebalance:
+		return "CompletingRebalance"
+	case structs.GroupStateStable:
+		return "Stable"
+	case structs.GroupStateDead:
+		return "Dead"
+	case structs.GroupStateEmpty:
+		return "Empty"
+	default:
+		return "Unknown"
+	}
 }
 
 func (b *Broker) handleStopReplica(ctx *Context, req *protocol.StopReplicaRequest) *protocol.StopReplicaResponse {
@@ -959,30 +995,121 @@ func (b *Broker) handleControlledShutdown(ctx *Context, req *protocol.Controlled
 }
 
 func (b *Broker) handleOffsetCommit(ctx *Context, req *protocol.OffsetCommitRequest) *protocol.OffsetCommitResponse {
-	panic("not implemented: offset commit")
-	return nil
+	sp := span(ctx, b.tracer, "offset commit")
+	defer sp.Finish()
+
+	res := new(protocol.OffsetCommitResponse)
+	res.APIVersion = req.Version()
+	res.Responses = make([]protocol.OffsetCommitTopicResponse, len(req.Topics))
+
+	state := b.fsm.State()
+	_, group, err := state.GetGroup(req.GroupID)
+	if err != nil {
+		for i, topic := range req.Topics {
+			res.Responses[i] = offsetCommitTopicResponse(topic, protocol.ErrUnknown.Code())
+		}
+		return res
+	}
+	if group == nil {
+		group = &structs.Group{
+			Group:       req.GroupID,
+			Coordinator: b.config.ID,
+			Members:     make(map[string]structs.Member),
+			Offsets:     make(map[string]map[int32]structs.Offset),
+		}
+	}
+	if group.Offsets == nil {
+		group.Offsets = make(map[string]map[int32]structs.Offset)
+	}
+	for _, topic := range req.Topics {
+		if group.Offsets[topic.Topic] == nil {
+			group.Offsets[topic.Topic] = make(map[int32]structs.Offset)
+		}
+		for _, partition := range topic.Partitions {
+			metadata := ""
+			if partition.Metadata != nil {
+				metadata = *partition.Metadata
+			}
+			group.Offsets[topic.Topic][partition.Partition] = structs.Offset{
+				Offset:   partition.Offset,
+				Metadata: metadata,
+			}
+		}
+	}
+	if _, err = b.raftApply(structs.RegisterGroupRequestType, structs.RegisterGroupRequest{Group: *group}); err != nil {
+		for i, topic := range req.Topics {
+			res.Responses[i] = offsetCommitTopicResponse(topic, protocol.ErrUnknown.Code())
+		}
+		return res
+	}
+	for i, topic := range req.Topics {
+		res.Responses[i] = offsetCommitTopicResponse(topic, protocol.ErrNone.Code())
+	}
+	return res
+}
+
+func offsetCommitTopicResponse(topic protocol.OffsetCommitTopicRequest, errorCode int16) protocol.OffsetCommitTopicResponse {
+	res := protocol.OffsetCommitTopicResponse{
+		Topic:              topic.Topic,
+		PartitionResponses: make([]protocol.OffsetCommitPartitionResponse, len(topic.Partitions)),
+	}
+	for i, partition := range topic.Partitions {
+		res.PartitionResponses[i] = protocol.OffsetCommitPartitionResponse{
+			Partition: partition.Partition,
+			ErrorCode: errorCode,
+		}
+	}
+	return res
 }
 
 func (b *Broker) handleOffsetFetch(ctx *Context, req *protocol.OffsetFetchRequest) *protocol.OffsetFetchResponse {
-	sp := span(ctx, b.tracer, "create topic")
+	sp := span(ctx, b.tracer, "offset fetch")
 	defer sp.Finish()
 
 	res := new(protocol.OffsetFetchResponse)
 	res.APIVersion = req.Version()
 	res.Responses = make([]protocol.OffsetFetchTopicResponse, len(req.Topics))
 
-	// state := b.fsm.State()
-
-	// _, g, err := state.GetGroup(req.GroupID)
-
-	// // If group doesn't exist then create it?
-	// if err != nil {
-	// 	// TODO: handle err
-	// 	panic(err)
-	// }
+	state := b.fsm.State()
+	_, group, err := state.GetGroup(req.GroupID)
+	if err != nil {
+		for i, topic := range req.Topics {
+			res.Responses[i] = offsetFetchTopicResponse(topic, nil, protocol.ErrUnknown.Code())
+		}
+		return res
+	}
+	for i, topic := range req.Topics {
+		var offsets map[int32]structs.Offset
+		if group != nil && group.Offsets != nil {
+			offsets = group.Offsets[topic.Topic]
+		}
+		res.Responses[i] = offsetFetchTopicResponse(topic, offsets, protocol.ErrNone.Code())
+	}
 
 	return res
 
+}
+
+func offsetFetchTopicResponse(topic protocol.OffsetFetchTopicRequest, offsets map[int32]structs.Offset, errorCode int16) protocol.OffsetFetchTopicResponse {
+	res := protocol.OffsetFetchTopicResponse{
+		Topic:      topic.Topic,
+		Partitions: make([]protocol.OffsetFetchPartition, len(topic.Partitions)),
+	}
+	for i, partition := range topic.Partitions {
+		offset := structs.Offset{Offset: -1}
+		if offsets != nil {
+			if stored, ok := offsets[partition]; ok {
+				offset = stored
+			}
+		}
+		res.Partitions[i] = protocol.OffsetFetchPartition{
+			Partition: partition,
+			Offset:    offset.Offset,
+			Metadata:  offset.Metadata,
+			ErrorCode: errorCode,
+		}
+	}
+	return res
 }
 
 // isController returns true if this is the cluster controller.

--- a/jocko/broker_test.go
+++ b/jocko/broker_test.go
@@ -1,3 +1,4 @@
+//go:build !race
 // +build !race
 
 package jocko
@@ -1014,32 +1015,31 @@ func TestBroker_LeftLeader(t *testing.T) {
 
 	leader.Shutdown()
 
-	var remain *Broker
+	var remaining []*Broker
 	for _, b := range brokers {
 		if b == leader {
 			continue
 		}
-		remain = b
+		remaining = append(remaining, b)
 		retry.Run(t, func(r *retry.R) { r.Check(wantPeers(b, 2)) })
 	}
 
-	retry.Run(t, func(r *retry.R) {
-		for _, b := range brokers {
-			if leader == b && b.isLeader() {
-				r.Fatal("should have new leader")
+	retry.RunWith(&retry.Timer{Timeout: 20 * time.Second, Wait: 25 * time.Millisecond}, t, func(r *retry.R) {
+		for _, b := range remaining {
+			if !b.isLeader() {
+				continue
 			}
-		}
-	})
-
-	state := remain.fsm.State()
-	retry.Run(t, func(r *retry.R) {
-		_, node, err := state.GetNode(leader.config.ID)
-		if err != nil {
-			r.Fatalf("err: %v", err)
-		}
-		if node != nil {
+			state := b.fsm.State()
+			_, node, err := state.GetNode(leader.config.ID)
+			if err != nil {
+				r.Fatalf("err: %v", err)
+			}
+			if node == nil {
+				return
+			}
 			r.Fatal("leader should be deregistered")
 		}
+		r.Fatal("should have new leader")
 	})
 }
 

--- a/jocko/server_test.go
+++ b/jocko/server_test.go
@@ -109,6 +109,101 @@ func TestKafkaClientProduceConsume(t *testing.T) {
 	}
 }
 
+func TestKafkaConsumerGroupProduceConsume(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv, dir := jocko.NewTestServer(t, func(cfg *config.Config) {
+		cfg.Bootstrap = true
+		cfg.BootstrapExpect = 1
+		cfg.StartAsLeader = true
+		cfg.OffsetsTopicReplicationFactor = 1
+	}, nil)
+	defer os.RemoveAll(dir)
+
+	err := srv.Start(ctx)
+	require.NoError(t, err)
+	defer srv.Shutdown()
+
+	jocko.WaitForLeader(t, srv)
+
+	err = createTopic(t, srv)
+	require.NoError(t, err)
+
+	config := cluster.NewConfig()
+	config.ClientID = "kafka-consumer-group-e2e-test"
+	config.Version = sarama.V0_10_0_0
+	config.ChannelBufferSize = 1
+	config.Producer.Return.Successes = true
+	config.Producer.RequiredAcks = sarama.WaitForAll
+	config.Producer.Retry.Max = 10
+	config.Consumer.Offsets.Initial = sarama.OffsetOldest
+	config.Consumer.Return.Errors = true
+
+	brokers := []string{srv.Addr().String()}
+	producer, err := sarama.NewSyncProducer(brokers, &config.Config)
+	require.NoError(t, err)
+	defer producer.Close()
+
+	firstValue := []byte("first consumer group message")
+	firstPartition, firstOffset, err := producer.SendMessage(&sarama.ProducerMessage{
+		Topic: topic,
+		Value: sarama.ByteEncoder(firstValue),
+	})
+	require.NoError(t, err)
+
+	groupID := "consumer-group-e2e"
+	consumer, err := cluster.NewConsumer(brokers, groupID, []string{topic}, config)
+	require.NoError(t, err)
+
+	firstMsg := waitForClusterMessage(t, consumer, 10*time.Second)
+	require.Equal(t, firstOffset, firstMsg.Offset)
+	require.Equal(t, firstPartition, firstMsg.Partition)
+	require.Equal(t, topic, firstMsg.Topic)
+	require.Equal(t, firstValue, firstMsg.Value)
+
+	consumer.MarkOffset(firstMsg, "first-done")
+	require.NoError(t, consumer.CommitOffsets())
+	require.NoError(t, consumer.Close())
+
+	secondValue := []byte("second consumer group message")
+	secondPartition, secondOffset, err := producer.SendMessage(&sarama.ProducerMessage{
+		Topic: topic,
+		Value: sarama.ByteEncoder(secondValue),
+	})
+	require.NoError(t, err)
+	require.Equal(t, firstPartition, secondPartition)
+	require.Equal(t, firstOffset+1, secondOffset)
+
+	consumer, err = cluster.NewConsumer(brokers, groupID, []string{topic}, config)
+	require.NoError(t, err)
+	defer consumer.Close()
+
+	secondMsg := waitForClusterMessage(t, consumer, 10*time.Second)
+	require.Equal(t, secondOffset, secondMsg.Offset)
+	require.Equal(t, secondPartition, secondMsg.Partition)
+	require.Equal(t, topic, secondMsg.Topic)
+	require.Equal(t, secondValue, secondMsg.Value)
+}
+
+func waitForClusterMessage(t *testing.T, consumer *cluster.Consumer, timeout time.Duration) *sarama.ConsumerMessage {
+	t.Helper()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	for {
+		select {
+		case msg := <-consumer.Messages():
+			return msg
+		case err := <-consumer.Errors():
+			require.NoError(t, err)
+		case <-timer.C:
+			t.Fatal("timed out waiting for consumer group message")
+		}
+	}
+}
+
 func TestProduceConsume(t *testing.T) {
 	t.Skip()
 

--- a/jocko/server_test.go
+++ b/jocko/server_test.go
@@ -186,6 +186,235 @@ func TestKafkaConsumerGroupProduceConsume(t *testing.T) {
 	require.Equal(t, secondValue, secondMsg.Value)
 }
 
+func TestKafkaConsumerGroupMultiMemberRebalance(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv, dir := jocko.NewTestServer(t, func(cfg *config.Config) {
+		cfg.Bootstrap = true
+		cfg.BootstrapExpect = 1
+		cfg.StartAsLeader = true
+		cfg.OffsetsTopicReplicationFactor = 1
+	}, nil)
+	defer os.RemoveAll(dir)
+
+	err := srv.Start(ctx)
+	require.NoError(t, err)
+	defer srv.Shutdown()
+
+	jocko.WaitForLeader(t, srv)
+
+	err = createTopicWithPartitions(t, srv, 4)
+	require.NoError(t, err)
+
+	brokers := []string{srv.Addr().String()}
+	producerConfig := sarama.NewConfig()
+	producerConfig.ClientID = "kafka-consumer-group-rebalance-producer"
+	producerConfig.Version = sarama.V0_10_0_0
+	producerConfig.Producer.Return.Successes = true
+	producerConfig.Producer.RequiredAcks = sarama.WaitForAll
+	producerConfig.Producer.Partitioner = sarama.NewManualPartitioner
+
+	producer, err := sarama.NewSyncProducer(brokers, producerConfig)
+	require.NoError(t, err)
+	defer producer.Close()
+
+	groupID := "consumer-group-rebalance-e2e"
+	consumerA, err := cluster.NewConsumer(brokers, groupID, []string{topic}, consumerGroupConfig("consumer-group-member-a"))
+	require.NoError(t, err)
+	defer consumerA.Close()
+
+	waitForConsumerPartitions(t, consumerA, 4, 10*time.Second)
+
+	consumerB, err := cluster.NewConsumer(brokers, groupID, []string{topic}, consumerGroupConfig("consumer-group-member-b"))
+	require.NoError(t, err)
+	defer consumerB.Close()
+
+	assignA, assignB := waitForBalancedConsumers(t, consumerA, consumerB, 4, 10*time.Second)
+
+	firstBatch := producePartitionMessages(t, producer, "first-rebalance", 4)
+	firstMessages := collectConsumerMessages(t, map[string]*cluster.Consumer{
+		"a": consumerA,
+		"b": consumerB,
+	}, firstBatch, 10*time.Second)
+	assertMessagesMatchAssignments(t, firstMessages, map[string]map[int32]bool{
+		"a": assignA,
+		"b": assignB,
+	})
+	commitCollectedMessages(t, firstMessages, map[string]*cluster.Consumer{
+		"a": consumerA,
+		"b": consumerB,
+	})
+
+	require.NoError(t, consumerB.Close())
+	waitForConsumerPartitions(t, consumerA, 4, 10*time.Second)
+
+	secondBatch := producePartitionMessages(t, producer, "after-leave", 4)
+	secondMessages := collectConsumerMessages(t, map[string]*cluster.Consumer{
+		"a": consumerA,
+	}, secondBatch, 10*time.Second)
+	require.Len(t, secondMessages, 4)
+	for _, msg := range secondMessages {
+		require.Equal(t, "a", msg.consumer)
+	}
+}
+
+func consumerGroupConfig(clientID string) *cluster.Config {
+	config := cluster.NewConfig()
+	config.ClientID = clientID
+	config.Version = sarama.V0_10_0_0
+	config.ChannelBufferSize = 1
+	config.Consumer.Offsets.Initial = sarama.OffsetOldest
+	config.Consumer.Return.Errors = true
+	return config
+}
+
+func waitForConsumerPartitions(t *testing.T, consumer *cluster.Consumer, want int, timeout time.Duration) map[int32]bool {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		partitions := partitionSet(consumer.Subscriptions())
+		if len(partitions) == want {
+			return partitions
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d partitions, got %v", want, consumer.Subscriptions())
+	return nil
+}
+
+func waitForBalancedConsumers(t *testing.T, consumerA, consumerB *cluster.Consumer, partitionCount int, timeout time.Duration) (map[int32]bool, map[int32]bool) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		assignA := partitionSet(consumerA.Subscriptions())
+		assignB := partitionSet(consumerB.Subscriptions())
+		if len(assignA) > 0 && len(assignB) > 0 && disjoint(assignA, assignB) && len(assignA)+len(assignB) == partitionCount {
+			return assignA, assignB
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for balanced consumers: a=%v b=%v", consumerA.Subscriptions(), consumerB.Subscriptions())
+	return nil, nil
+}
+
+func partitionSet(subscriptions map[string][]int32) map[int32]bool {
+	partitions := make(map[int32]bool)
+	for _, topicPartitions := range subscriptions {
+		for _, partition := range topicPartitions {
+			partitions[partition] = true
+		}
+	}
+	return partitions
+}
+
+func disjoint(a, b map[int32]bool) bool {
+	for partition := range a {
+		if b[partition] {
+			return false
+		}
+	}
+	return true
+}
+
+func producePartitionMessages(t *testing.T, producer sarama.SyncProducer, prefix string, partitionCount int32) map[int32][]byte {
+	t.Helper()
+
+	messages := make(map[int32][]byte, partitionCount)
+	for partition := int32(0); partition < partitionCount; partition++ {
+		value := []byte(fmt.Sprintf("%s-partition-%d", prefix, partition))
+		producedPartition, _, err := producer.SendMessage(&sarama.ProducerMessage{
+			Topic:     topic,
+			Partition: partition,
+			Value:     sarama.ByteEncoder(value),
+		})
+		require.NoError(t, err)
+		require.Equal(t, partition, producedPartition)
+		messages[partition] = value
+	}
+	return messages
+}
+
+type collectedConsumerMessage struct {
+	consumer string
+	message  *sarama.ConsumerMessage
+}
+
+func collectConsumerMessages(t *testing.T, consumers map[string]*cluster.Consumer, expected map[int32][]byte, timeout time.Duration) map[int32]collectedConsumerMessage {
+	t.Helper()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	messages := make(map[int32]collectedConsumerMessage, len(expected))
+	for len(messages) < len(expected) {
+		select {
+		case msg := <-consumers["a"].Messages():
+			collectExpectedMessage(t, messages, "a", msg, expected)
+		case err := <-consumers["a"].Errors():
+			require.NoError(t, err)
+		case msg := <-messageChannel(consumers["b"]):
+			collectExpectedMessage(t, messages, "b", msg, expected)
+		case err := <-errorChannel(consumers["b"]):
+			require.NoError(t, err)
+		case <-timer.C:
+			t.Fatalf("timed out waiting for messages: got %d, want %d", len(messages), len(expected))
+		}
+	}
+	return messages
+}
+
+func collectExpectedMessage(t *testing.T, messages map[int32]collectedConsumerMessage, consumer string, msg *sarama.ConsumerMessage, expected map[int32][]byte) {
+	t.Helper()
+
+	value, ok := expected[msg.Partition]
+	if !ok {
+		return
+	}
+	if _, seen := messages[msg.Partition]; seen {
+		return
+	}
+	require.Equal(t, topic, msg.Topic)
+	require.Equal(t, value, msg.Value)
+	messages[msg.Partition] = collectedConsumerMessage{consumer: consumer, message: msg}
+}
+
+func messageChannel(consumer *cluster.Consumer) <-chan *sarama.ConsumerMessage {
+	if consumer == nil {
+		return nil
+	}
+	return consumer.Messages()
+}
+
+func errorChannel(consumer *cluster.Consumer) <-chan error {
+	if consumer == nil {
+		return nil
+	}
+	return consumer.Errors()
+}
+
+func assertMessagesMatchAssignments(t *testing.T, messages map[int32]collectedConsumerMessage, assignments map[string]map[int32]bool) {
+	t.Helper()
+
+	require.Len(t, messages, 4)
+	for partition, msg := range messages {
+		require.True(t, assignments[msg.consumer][partition], "consumer %s received unassigned partition %d", msg.consumer, partition)
+	}
+}
+
+func commitCollectedMessages(t *testing.T, messages map[int32]collectedConsumerMessage, consumers map[string]*cluster.Consumer) {
+	t.Helper()
+
+	for _, msg := range messages {
+		consumers[msg.consumer].MarkOffset(msg.message, "")
+	}
+	for _, consumer := range consumers {
+		require.NoError(t, consumer.CommitOffsets())
+	}
+}
+
 func waitForClusterMessage(t *testing.T, consumer *cluster.Consumer, timeout time.Duration) *sarama.ConsumerMessage {
 	t.Helper()
 
@@ -560,6 +789,10 @@ func BenchmarkServer(b *testing.B) {
 }
 
 func createTopic(t ti.T, s1 *jocko.Server, other ...*jocko.Server) error {
+	return createTopicWithPartitions(t, s1, 1, other...)
+}
+
+func createTopicWithPartitions(t ti.T, s1 *jocko.Server, partitions int32, other ...*jocko.Server) error {
 	d := &jocko.Dialer{
 		Timeout:   10 * time.Second,
 		DualStack: true,
@@ -573,15 +806,17 @@ func createTopic(t ti.T, s1 *jocko.Server, other ...*jocko.Server) error {
 	for _, o := range other {
 		assignment = append(assignment, o.ID())
 	}
+	replicaAssignment := make(map[int32][]int32, partitions)
+	for partition := int32(0); partition < partitions; partition++ {
+		replicaAssignment[partition] = assignment
+	}
 	res, err := conn.CreateTopics(&protocol.CreateTopicRequests{
 		Timeout: 15 * time.Second,
 		Requests: []*protocol.CreateTopicRequest{{
 			Topic:             topic,
-			NumPartitions:     int32(1),
+			NumPartitions:     partitions,
 			ReplicationFactor: int16(len(assignment)),
-			ReplicaAssignment: map[int32][]int32{
-				0: assignment,
-			},
+			ReplicaAssignment: replicaAssignment,
 			Configs: map[string]*string{
 				"config_key": strPointer("config_val"),
 			},

--- a/jocko/structs/structs.go
+++ b/jocko/structs/structs.go
@@ -155,9 +155,10 @@ type Partition struct {
 
 // Member
 type Member struct {
-	ID         string
-	Metadata   []byte
-	Assignment []byte
+	ID               string
+	Metadata         []byte
+	Assignment       []byte
+	JoinedGeneration int32
 }
 
 type Offset struct {

--- a/jocko/structs/structs.go
+++ b/jocko/structs/structs.go
@@ -160,6 +160,11 @@ type Member struct {
 	Assignment []byte
 }
 
+type Offset struct {
+	Offset   int64
+	Metadata string
+}
+
 type GroupState int32
 
 const (
@@ -177,6 +182,7 @@ type Group struct {
 	Coordinator  int32
 	LeaderID     string
 	Members      map[string]Member
+	Offsets      map[string]map[int32]Offset
 	State        GroupState
 	GenerationID int32
 

--- a/protocol/join_group_request.go
+++ b/protocol/join_group_request.go
@@ -30,6 +30,9 @@ func (r *JoinGroupRequest) Encode(e PacketEncoder) (err error) {
 	if err = e.PutString(r.ProtocolType); err != nil {
 		return err
 	}
+	if err = e.PutArrayLength(len(r.GroupProtocols)); err != nil {
+		return err
+	}
 	for _, groupProtocol := range r.GroupProtocols {
 		if err = e.PutString(groupProtocol.ProtocolName); err != nil {
 			return err

--- a/protocol/offset_commit_request.go
+++ b/protocol/offset_commit_request.go
@@ -26,17 +26,36 @@ func (r *OffsetCommitRequest) Encode(e PacketEncoder) (err error) {
 	if err = e.PutString(r.GroupID); err != nil {
 		return err
 	}
+	if r.APIVersion >= 1 {
+		e.PutInt32(r.GenerationID)
+		if err := e.PutString(r.MemberID); err != nil {
+			return err
+		}
+	}
+	if r.APIVersion >= 2 {
+		e.PutInt64(r.RetentionTime)
+	}
 	if err := e.PutArrayLength(len(r.Topics)); err != nil {
 		return err
 	}
 	for _, t := range r.Topics {
+		if err := e.PutString(t.Topic); err != nil {
+			return err
+		}
 		if err := e.PutArrayLength(len(t.Partitions)); err != nil {
 			return err
 		}
 		for _, p := range t.Partitions {
 			e.PutInt32(p.Partition)
 			e.PutInt64(p.Offset)
-			if err := e.PutNullableString(p.Metadata); err != nil {
+			if r.APIVersion == 1 {
+				e.PutInt64(p.Timestamp)
+			}
+			metadata := ""
+			if p.Metadata != nil {
+				metadata = *p.Metadata
+			}
+			if err := e.PutString(metadata); err != nil {
 				return err
 			}
 		}
@@ -68,27 +87,32 @@ func (r *OffsetCommitRequest) Decode(d PacketDecoder, version int16) (err error)
 		return err
 	}
 	r.Topics = make([]OffsetCommitTopicRequest, topicCount)
-	for _, t := range r.Topics {
+	for i := range r.Topics {
+		if r.Topics[i].Topic, err = d.String(); err != nil {
+			return err
+		}
 		partitionCount, err := d.ArrayLength()
 		if err != nil {
 			return err
 		}
-		t.Partitions = make([]OffsetCommitPartitionRequest, partitionCount)
-		for _, p := range t.Partitions {
-			if p.Partition, err = d.Int32(); err != nil {
+		r.Topics[i].Partitions = make([]OffsetCommitPartitionRequest, partitionCount)
+		for j := range r.Topics[i].Partitions {
+			if r.Topics[i].Partitions[j].Partition, err = d.Int32(); err != nil {
 				return err
 			}
-			if p.Offset, err = d.Int64(); err != nil {
+			if r.Topics[i].Partitions[j].Offset, err = d.Int64(); err != nil {
 				return err
 			}
-			if version >= 1 {
-				if p.Timestamp, err = d.Int64(); err != nil {
+			if version == 1 {
+				if r.Topics[i].Partitions[j].Timestamp, err = d.Int64(); err != nil {
 					return err
 				}
 			}
-			if p.Metadata, err = d.NullableString(); err != nil {
+			metadata, err := d.String()
+			if err != nil {
 				return err
 			}
+			r.Topics[i].Partitions[j].Metadata = &metadata
 		}
 	}
 	return nil

--- a/protocol/offset_commit_response.go
+++ b/protocol/offset_commit_response.go
@@ -57,21 +57,21 @@ func (r *OffsetCommitResponse) Decode(d PacketDecoder, version int16) (err error
 		return err
 	}
 	r.Responses = make([]OffsetCommitTopicResponse, topicCount)
-	for _, t := range r.Responses {
-		if t.Topic, err = d.String(); err != nil {
+	for i := range r.Responses {
+		if r.Responses[i].Topic, err = d.String(); err != nil {
 			return err
 		}
 		partitionCount, err := d.ArrayLength()
 		if err != nil {
 			return err
 		}
-		t.PartitionResponses = make([]OffsetCommitPartitionResponse, partitionCount)
-		for _, p := range t.PartitionResponses {
-			p.Partition, err = d.Int32()
+		r.Responses[i].PartitionResponses = make([]OffsetCommitPartitionResponse, partitionCount)
+		for j := range r.Responses[i].PartitionResponses {
+			r.Responses[i].PartitionResponses[j].Partition, err = d.Int32()
 			if err != nil {
 				return err
 			}
-			p.ErrorCode, err = d.Int16()
+			r.Responses[i].PartitionResponses[j].ErrorCode, err = d.Int16()
 			if err != nil {
 				return err
 			}

--- a/protocol/offset_fetch_response.go
+++ b/protocol/offset_fetch_response.go
@@ -7,8 +7,8 @@ type OffsetFetchTopicResponse struct {
 
 type OffsetFetchPartition struct {
 	Partition int32
-	Offset    int16
-	Metadata  *string
+	Offset    int64
+	Metadata  string
 	ErrorCode int16
 }
 
@@ -31,8 +31,8 @@ func (r *OffsetFetchResponse) Encode(e PacketEncoder) (err error) {
 		}
 		for _, p := range resp.Partitions {
 			e.PutInt32(p.Partition)
-			e.PutInt16(p.Offset)
-			if err := e.PutNullableString(p.Metadata); err != nil {
+			e.PutInt64(p.Offset)
+			if err := e.PutString(p.Metadata); err != nil {
 				return err
 			}
 			e.PutInt16(p.ErrorCode)
@@ -49,26 +49,26 @@ func (r *OffsetFetchResponse) Decode(d PacketDecoder, version int16) (err error)
 		return err
 	}
 	r.Responses = make([]OffsetFetchTopicResponse, responses)
-	for _, resp := range r.Responses {
-		if resp.Topic, err = d.String(); err != nil {
+	for i := range r.Responses {
+		if r.Responses[i].Topic, err = d.String(); err != nil {
 			return err
 		}
 		partitions, err := d.ArrayLength()
 		if err != nil {
 			return err
 		}
-		resp.Partitions = make([]OffsetFetchPartition, partitions)
-		for _, p := range resp.Partitions {
-			if p.Partition, err = d.Int32(); err != nil {
+		r.Responses[i].Partitions = make([]OffsetFetchPartition, partitions)
+		for j := range r.Responses[i].Partitions {
+			if r.Responses[i].Partitions[j].Partition, err = d.Int32(); err != nil {
 				return err
 			}
-			if p.Offset, err = d.Int16(); err != nil {
+			if r.Responses[i].Partitions[j].Offset, err = d.Int64(); err != nil {
 				return err
 			}
-			if p.Metadata, err = d.NullableString(); err != nil {
+			if r.Responses[i].Partitions[j].Metadata, err = d.String(); err != nil {
 				return err
 			}
-			if p.ErrorCode, err = d.Int16(); err != nil {
+			if r.Responses[i].Partitions[j].ErrorCode, err = d.Int16(); err != nil {
 				return err
 			}
 		}


### PR DESCRIPTION
## Summary

- Implement the minimum Kafka consumer group path needed by Go Kafka clients: JoinGroup, SyncGroup, Heartbeat, LeaveGroup, OffsetFetch, and OffsetCommit.
- Persist consumer group member assignments and committed offsets in group state.
- Fix JoinGroup, OffsetCommit, and OffsetFetch protocol wire encoding/decoding issues exercised by the client path.
- Add an active sarama-cluster e2e that consumes through a group, commits the first offset, recreates the same group, and verifies consumption resumes at the second message.

## Validation

- `go test ./jocko -run '^TestKafkaConsumerGroupProduceConsume$' -count=1`\n- `go test ./...`\n\n## Notes\n\nThis covers the current single-member consumer group path. Full multi-member rebalance semantics are still future work.