### PR TITLE
Implement replicated partition leader failover

### DIFF
--- a/commitlog/segment.go
+++ b/commitlog/segment.go
@@ -214,10 +214,10 @@ func (s *Segment) findEntry(offset int64) (e *Entry, err error) {
 	s.Lock()
 	defer s.Unlock()
 	e = &Entry{}
-	n := int(s.Index.bytes / entryWidth)
+	n := int(s.Index.position / entryWidth)
 	idx := sort.Search(n, func(i int) bool {
 		_ = s.Index.ReadEntryAtFileOffset(e, int64(i*entryWidth))
-		return e.Offset >= offset || e.Offset == 0
+		return e.Offset >= offset
 	})
 	if idx == n {
 		return nil, errors.New("entry not found")

--- a/jocko/broker.go
+++ b/jocko/broker.go
@@ -127,6 +127,22 @@ func NewBroker(config *config.Config, tracer opentracing.Tracer) (*Broker, error
 
 // Run starts a loop to handle requests send back responses.
 func (b *Broker) Run(ctx context.Context, requests <-chan *Context, responses chan<- *Context) {
+	sendResponse := func(reqCtx *Context, res protocol.ResponseBody) {
+		parentSpan := opentracing.SpanFromContext(reqCtx)
+		queueSpan := b.tracer.StartSpan("broker: queue response", opentracing.ChildOf(parentSpan.Context()))
+		responseCtx := context.WithValue(reqCtx, responseQueueSpanKey, queueSpan)
+
+		responses <- &Context{
+			parent: responseCtx,
+			conn:   reqCtx.conn,
+			header: reqCtx.header,
+			res: &protocol.Response{
+				CorrelationID: reqCtx.header.CorrelationID,
+				Body:          res,
+			},
+		}
+	}
+
 	for {
 		select {
 		case reqCtx := <-requests:
@@ -145,6 +161,12 @@ func (b *Broker) Run(ctx context.Context, requests <-chan *Context, responses ch
 
 			switch req := reqCtx.req.(type) {
 			case *protocol.ProduceRequest:
+				if req.Acks == -1 {
+					go func() {
+						sendResponse(reqCtx, b.handleProduce(reqCtx, req))
+					}()
+					continue
+				}
 				res = b.handleProduce(reqCtx, req)
 			case *protocol.FetchRequest:
 				res = b.handleFetch(reqCtx, req)
@@ -188,19 +210,7 @@ func (b *Broker) Run(ctx context.Context, requests <-chan *Context, responses ch
 				res = b.handleDeleteTopics(reqCtx, req)
 			}
 
-			parentSpan := opentracing.SpanFromContext(reqCtx)
-			queueSpan = b.tracer.StartSpan("broker: queue response", opentracing.ChildOf(parentSpan.Context()))
-			responseCtx := context.WithValue(reqCtx, responseQueueSpanKey, queueSpan)
-
-			responses <- &Context{
-				parent: responseCtx,
-				conn:   reqCtx.conn,
-				header: reqCtx.header,
-				res: &protocol.Response{
-					CorrelationID: reqCtx.header.CorrelationID,
-					Body:          res,
-				},
-			}
+			sendResponse(reqCtx, res)
 		case <-ctx.Done():
 			goto DONE
 		}
@@ -265,7 +275,7 @@ func (b *Broker) handleCreateTopic(ctx *Context, reqs *protocol.CreateTopicReque
 			}
 			continue
 		}
-		if req.ReplicationFactor > int16(len(b.LANMembers())) {
+		if len(req.ReplicaAssignment) == 0 && req.ReplicationFactor > int16(len(b.LANMembers())) {
 			res.TopicErrorCodes[i] = &protocol.TopicErrorCode{
 				Topic:     req.Topic,
 				ErrorCode: protocol.ErrInvalidReplicationFactor.Code(),
@@ -334,22 +344,29 @@ func (b *Broker) handleLeaderAndISR(ctx *Context, req *protocol.LeaderAndISRRequ
 		}
 	}
 	for i, p := range req.PartitionStates {
-		// TODO: need to replace the replica regardless
-		replica := &Replica{
-			BrokerID: b.config.ID,
-			Partition: structs.Partition{
-				ID:              p.Partition,
-				Partition:       p.Partition,
-				Topic:           p.Topic,
-				ISR:             p.ISR,
-				AR:              p.Replicas,
-				ControllerEpoch: p.ZKVersion,
-				LeaderEpoch:     p.LeaderEpoch,
-				Leader:          p.Leader,
-			},
-			IsLocal: true,
+		if !contains(p.Replicas, b.config.ID) {
+			replica, err := b.replicaLookup.Replica(p.Topic, p.Partition)
+			if err == nil && replica != nil {
+				if replica.Replicator != nil {
+					if err := replica.Replicator.Close(); err != nil {
+						setErr(i, p, protocol.ErrUnknown.WithErr(err))
+						continue
+					}
+				}
+				b.replicaLookup.RemoveReplica(replica)
+			}
+			res.Partitions[i] = &protocol.LeaderAndISRPartition{Partition: p.Partition, Topic: p.Topic, ErrorCode: protocol.ErrNone.Code()}
+			continue
 		}
-		b.replicaLookup.AddReplica(replica)
+
+		replica, err := b.replicaLookup.Replica(p.Topic, p.Partition)
+		if err != nil || replica == nil {
+			replica = &Replica{BrokerID: b.config.ID, IsLocal: true}
+			replica.setPartitionState(p)
+			b.replicaLookup.AddReplica(replica)
+		} else {
+			replica.setPartitionState(p)
+		}
 
 		if p.Leader == b.config.ID && (replica.Partition.Leader == b.config.ID) {
 			// is command asking this broker to be the new leader for p and this broker is not already the leader for
@@ -397,6 +414,7 @@ func (b *Broker) handleOffsets(ctx *Context, req *protocol.OffsetsRequest) *prot
 			if err != nil {
 				// TODO: have replica lookup return an error with a code
 				pres.ErrorCode = protocol.ErrUnknown.Code()
+				res.Responses[i].PartitionResponses = append(res.Responses[i].PartitionResponses, pres)
 				continue
 			}
 			var offset int64
@@ -443,6 +461,9 @@ func (b *Broker) handleProduce(ctx *Context, req *protocol.ProduceRequest) *prot
 					pres.Partition = p.Partition
 					return protocol.ErrReplicaNotAvailable
 				}
+				if replica.Partition.Leader != b.config.ID {
+					return protocol.ErrNotLeaderForPartition
+				}
 				offset, appendErr := replica.Log.Append(p.RecordSet)
 				if appendErr != nil {
 					log.Error.Printf("broker/%d: log append error: %s", b.config.ID, err)
@@ -450,6 +471,10 @@ func (b *Broker) handleProduce(ctx *Context, req *protocol.ProduceRequest) *prot
 				}
 				pres.BaseOffset = offset
 				pres.LogAppendTime = time.Now()
+				targetOffset := replica.updateLeaderLogEnd()
+				if req.Acks == -1 && !replica.waitForHighWatermark(targetOffset, req.Timeout) {
+					return protocol.ErrRequestTimedOut
+				}
 				return protocol.ErrNone
 			})
 			pres.ErrorCode = err.Code()
@@ -955,33 +980,26 @@ func (b *Broker) handleFetch(ctx *Context, r *protocol.FetchRequest) *protocol.F
 					return protocol.ErrReplicaNotAvailable
 				}
 				newestOffset := replica.Log.NewestOffset()
-				if p.FetchOffset >= newestOffset {
-					fpres.HighWatermark = newestOffset
+				replicaFetch := r.ReplicaID >= 0
+				readableOffset := newestOffset
+				if !replicaFetch {
+					readableOffset = replica.highWatermark()
+				}
+				if replicaFetch {
+					replica.updateFollowerProgress(r.ReplicaID, p.FetchOffset)
+				}
+				if p.FetchOffset >= readableOffset {
+					fpres.HighWatermark = replica.highWatermark()
 					fpres.RecordSet = []byte{}
 					return protocol.ErrNone
 				}
-				rdr, rdrErr := replica.Log.NewReader(p.FetchOffset, p.MaxBytes)
+				recordSet, rdrErr := readRecordSetRange(replica.Log, p.FetchOffset, readableOffset, p.MaxBytes)
 				if rdrErr != nil {
 					log.Error.Printf("broker/%d: replica log read error: %s", b.config.ID, rdrErr)
 					return protocol.ErrUnknown.WithErr(rdrErr)
 				}
-				buf := new(bytes.Buffer)
-				var n int32
-				for n < r.MinBytes {
-					// TODO: copy these bytes to outer bytes
-					nn, err := io.Copy(buf, rdr)
-					if err != nil && err != io.EOF {
-						log.Error.Printf("broker/%d: reader copy error", b.config.ID, err)
-						return protocol.ErrUnknown.WithErr(rdrErr)
-					}
-					n += int32(nn)
-					if err == io.EOF {
-						// TODO: should use a different error here?
-						break
-					}
-				}
-				fpres.HighWatermark = newestOffset - 1
-				fpres.RecordSet = buf.Bytes()
+				fpres.HighWatermark = replica.highWatermark()
+				fpres.RecordSet = recordSet
 				return protocol.ErrNone
 			})
 			fpres.ErrorCode = err.Code()
@@ -1233,11 +1251,11 @@ func (b *Broker) startReplica(replica *Replica) protocol.Error {
 	state := b.fsm.State()
 	_, topic, _ := state.GetTopic(replica.Partition.Topic)
 
-	// TODO: think i need to just ensure/add the topic if it's not here yet
-
+	topicConfig := structs.NewTopicConfig()
 	if topic == nil {
-		log.Info.Printf("broker/%d: start replica called on unknown topic: %s", b.config.ID, replica.Partition.Topic)
-		return protocol.ErrUnknownTopicOrPartition
+		log.Info.Printf("broker/%d: starting replica before local topic state is applied: %s", b.config.ID, replica.Partition.Topic)
+	} else if topic.Config != nil {
+		topicConfig = topic.Config
 	}
 
 	if replica.Log == nil {
@@ -1245,7 +1263,7 @@ func (b *Broker) startReplica(replica *Replica) protocol.Error {
 			Path:            filepath.Join(b.config.DataDir, "data", fmt.Sprintf("%d", replica.Partition.ID)),
 			MaxSegmentBytes: 1024,
 			MaxLogBytes:     -1,
-			CleanupPolicy:   commitlog.CleanupPolicy(topic.Config.GetValue("cleanup.policy").(string)),
+			CleanupPolicy:   commitlog.CleanupPolicy(topicConfig.GetValue("cleanup.policy").(string)),
 		})
 		if err != nil {
 			return protocol.ErrUnknown.WithErr(err)
@@ -1264,9 +1282,12 @@ func (b *Broker) createTopic(ctx *Context, topic *protocol.CreateTopicRequest) p
 	if t != nil {
 		return protocol.ErrTopicAlreadyExists
 	}
-	ps, err := b.buildPartitions(topic.Topic, topic.NumPartitions, topic.ReplicationFactor)
-	if err != protocol.ErrNone {
-		return err
+	ps, protocolErr := b.buildPartitions(topic.Topic, topic.NumPartitions, topic.ReplicationFactor)
+	if len(topic.ReplicaAssignment) > 0 {
+		ps, protocolErr = b.buildAssignedPartitions(topic.Topic, topic.NumPartitions, topic.ReplicationFactor, topic.ReplicaAssignment)
+	}
+	if protocolErr != protocol.ErrNone {
+		return protocolErr
 	}
 	tt := structs.Topic{
 		Topic:      topic.Topic,
@@ -1300,19 +1321,34 @@ func (b *Broker) createTopic(ctx *Context, topic *protocol.CreateTopicRequest) p
 			Replicas: partition.AR,
 		})
 	}
-	// TODO: can optimize this
+	_, nodes, err := state.GetNodes()
+	if err != nil {
+		return protocol.ErrUnknown.WithErr(err)
+	}
+	brokerAddrs := make(map[int32]string)
+	for _, node := range nodes {
+		if node.Check == nil || node.Check.Status != structs.HealthPassing {
+			continue
+		}
+		brokerAddrs[node.Node] = node.Address
+	}
 	for _, broker := range b.brokerLookup.Brokers() {
-		if broker.ID.Int32() == b.config.ID {
+		brokerAddrs[broker.ID.Int32()] = broker.BrokerAddr
+	}
+	// TODO: can optimize this
+	for brokerID, brokerAddr := range brokerAddrs {
+		if brokerID == b.config.ID {
 			errCode := b.handleLeaderAndISR(ctx, req).ErrorCode
 			if protocol.ErrNone.Code() != errCode {
 				panic(fmt.Sprintf("broker/%d: handling leader and isr error: %d", b.config.ID, errCode))
 			}
 		} else {
-			conn, err := Dial("tcp", broker.BrokerAddr)
+			conn, err := Dial("tcp", brokerAddr)
 			if err != nil {
 				return protocol.ErrUnknown.WithErr(err)
 			}
 			res, err := conn.LeaderAndISR(req)
+			_ = conn.Close()
 			if err != nil {
 				// handle err and responses
 				return protocol.ErrUnknown.WithErr(err)
@@ -1360,6 +1396,26 @@ func (b *Broker) buildPartitions(topic string, partitionsCount int32, replicatio
 		partitions = append(partitions, partition)
 	}
 
+	return partitions, protocol.ErrNone
+}
+
+func (b *Broker) buildAssignedPartitions(topic string, partitionsCount int32, replicationFactor int16, assignment map[int32][]int32) ([]structs.Partition, protocol.Error) {
+	partitions := make([]structs.Partition, 0, partitionsCount)
+	for i := int32(0); i < partitionsCount; i++ {
+		replicas, ok := assignment[i]
+		if !ok || len(replicas) == 0 {
+			return nil, protocol.ErrInvalidReplicationFactor
+		}
+		replicaSet := append([]int32(nil), replicas...)
+		partitions = append(partitions, structs.Partition{
+			Topic:     topic,
+			ID:        i,
+			Partition: i,
+			Leader:    replicaSet[0],
+			AR:        replicaSet,
+			ISR:       replicaSet,
+		})
+	}
 	return partitions, protocol.ErrNone
 }
 
@@ -1458,10 +1514,6 @@ func (b *Broker) becomeFollower(replica *Replica, cmd *protocol.PartitionState) 
 			return protocol.ErrUnknown.WithErr(err)
 		}
 	}
-	hw := replica.Log.NewestOffset()
-	if err := replica.Log.Truncate(hw); err != nil {
-		return protocol.ErrUnknown.WithErr(err)
-	}
 	broker := b.brokerLookup.BrokerByID(raft.ServerID(fmt.Sprintf("%d", cmd.Leader)))
 	if broker == nil {
 		return protocol.ErrBrokerNotAvailable
@@ -1470,6 +1522,7 @@ func (b *Broker) becomeFollower(replica *Replica, cmd *protocol.PartitionState) 
 	if err != nil {
 		return protocol.ErrUnknown.WithErr(err)
 	}
+	replica.setPartitionState(cmd)
 	r := NewReplicator(ReplicatorConfig{}, replica, conn)
 	replica.Replicator = r
 	if !b.config.DevMode {
@@ -1487,10 +1540,8 @@ func (b *Broker) becomeLeader(replica *Replica, cmd *protocol.PartitionState) pr
 		}
 		replica.Replicator = nil
 	}
-	replica.Partition.Leader = cmd.Leader
-	replica.Partition.AR = cmd.Replicas
-	replica.Partition.ISR = cmd.ISR
-	replica.Partition.LeaderEpoch = cmd.ZKVersion
+	replica.setPartitionState(cmd)
+	replica.initializeLeaderProgress()
 	return protocol.ErrNone
 }
 
@@ -1501,6 +1552,42 @@ func contains(rs []int32, r int32) bool {
 		}
 	}
 	return false
+}
+
+func readRecordSetRange(log CommitLog, startOffset, endOffset int64, maxBytes int32) ([]byte, error) {
+	if startOffset >= endOffset {
+		return []byte{}, nil
+	}
+	rdr, err := log.NewReader(startOffset, maxBytes)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	for offset := startOffset; offset < endOffset; offset++ {
+		header := make([]byte, 12)
+		if _, err := io.ReadFull(rdr, header); err != nil {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
+				break
+			}
+			return nil, err
+		}
+		size := int32(protocol.Encoding.Uint32(header[8:12]))
+		recordSet := make([]byte, 12+size)
+		copy(recordSet, header)
+		if _, err := io.ReadFull(rdr, recordSet[12:]); err != nil {
+			return nil, err
+		}
+		if maxBytes > 0 && int32(buf.Len()+len(recordSet)) > maxBytes && buf.Len() > 0 {
+			break
+		}
+		if _, err := buf.Write(recordSet); err != nil {
+			return nil, err
+		}
+	}
+	if buf.Len() == 0 {
+		return []byte{}, nil
+	}
+	return buf.Bytes(), nil
 }
 
 // ensurePath is used to make sure a path exists
@@ -1547,18 +1634,133 @@ func (b *Broker) LANMembers() []serf.Member {
 
 // Replica
 type Replica struct {
-	BrokerID   int32
-	Partition  structs.Partition
-	IsLocal    bool
-	Log        CommitLog
-	Hw         int64
-	Leo        int64
-	Replicator *Replicator
+	BrokerID    int32
+	Partition   structs.Partition
+	IsLocal     bool
+	Log         CommitLog
+	Hw          int64
+	Leo         int64
+	ISRProgress map[int32]int64
+	Replicator  *Replicator
 	sync.Mutex
 }
 
 func (r Replica) String() string {
 	return fmt.Sprintf("replica: %d {broker: %d, leader: %d, hw: %d, leo: %d}", r.Partition.ID, r.BrokerID, r.Partition.Leader, r.Hw, r.Leo)
+}
+
+func (r *Replica) setPartitionState(p *protocol.PartitionState) {
+	r.Lock()
+	defer r.Unlock()
+	r.IsLocal = true
+	r.Partition = structs.Partition{
+		ID:              p.Partition,
+		Partition:       p.Partition,
+		Topic:           p.Topic,
+		ISR:             p.ISR,
+		AR:              p.Replicas,
+		ControllerEpoch: p.ZKVersion,
+		LeaderEpoch:     p.LeaderEpoch,
+		Leader:          p.Leader,
+	}
+}
+
+func (r *Replica) initializeLeaderProgress() int64 {
+	r.Lock()
+	defer r.Unlock()
+	if r.ISRProgress == nil {
+		r.ISRProgress = make(map[int32]int64)
+	}
+	localEnd := r.logEndLocked()
+	for follower := range r.ISRProgress {
+		if !contains(r.Partition.ISR, follower) {
+			delete(r.ISRProgress, follower)
+		}
+	}
+	for _, isr := range r.Partition.ISR {
+		if isr == r.BrokerID {
+			r.ISRProgress[isr] = localEnd
+			continue
+		}
+		if _, ok := r.ISRProgress[isr]; !ok {
+			r.ISRProgress[isr] = 0
+		}
+	}
+	r.updateHighWatermarkLocked()
+	return r.Hw
+}
+
+func (r *Replica) updateLeaderLogEnd() int64 {
+	r.Lock()
+	defer r.Unlock()
+	if r.ISRProgress == nil {
+		r.ISRProgress = make(map[int32]int64)
+	}
+	localEnd := r.logEndLocked()
+	r.ISRProgress[r.BrokerID] = localEnd
+	r.updateHighWatermarkLocked()
+	return localEnd
+}
+
+func (r *Replica) updateFollowerProgress(follower int32, offset int64) {
+	r.Lock()
+	defer r.Unlock()
+	if r.ISRProgress == nil || !contains(r.Partition.ISR, follower) {
+		return
+	}
+	if offset > r.ISRProgress[follower] {
+		r.ISRProgress[follower] = offset
+	}
+	r.updateHighWatermarkLocked()
+}
+
+func (r *Replica) highWatermark() int64 {
+	r.Lock()
+	defer r.Unlock()
+	return r.Hw
+}
+
+func (r *Replica) waitForHighWatermark(offset int64, timeout time.Duration) bool {
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if r.highWatermark() >= offset {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return r.highWatermark() >= offset
+}
+
+func (r *Replica) logEndLocked() int64 {
+	if r.Log == nil {
+		r.Leo = 0
+		return 0
+	}
+	r.Leo = r.Log.NewestOffset()
+	return r.Leo
+}
+
+func (r *Replica) updateHighWatermarkLocked() {
+	if len(r.Partition.ISR) == 0 {
+		r.Hw = r.logEndLocked()
+		return
+	}
+	hw := int64(-1)
+	for _, isr := range r.Partition.ISR {
+		offset, ok := r.ISRProgress[isr]
+		if !ok {
+			offset = 0
+		}
+		if hw == -1 || offset < hw {
+			hw = offset
+		}
+	}
+	if hw > r.Hw {
+		r.Hw = hw
+	}
 }
 
 func (b *Broker) offsetsTopic(ctx *Context) (topic *structs.Topic, err error) {

--- a/jocko/broker_test.go
+++ b/jocko/broker_test.go
@@ -285,7 +285,7 @@ func TestBroker_Run(t *testing.T) {
 								PartitionResponses: []*protocol.FetchPartitionResponse{{
 									Partition:     0,
 									ErrorCode:     protocol.ErrNone.Code(),
-									HighWatermark: 0,
+									HighWatermark: 1,
 									RecordSet:     mustEncode(&protocol.MessageSet{Offset: 0, Messages: []*protocol.Message{{Value: []byte("The message.")}}}),
 								}},
 							}}},

--- a/jocko/leader.go
+++ b/jocko/leader.go
@@ -268,7 +268,7 @@ func (b *Broker) reconcileMember(m serf.Member) error {
 		err = b.handleLeftMember(m)
 	}
 	if err != nil {
-		log.Error.Printf("leader/%d: reconcile member: %s: error: %s", m.Name, b.config.ID, err)
+		log.Error.Printf("leader/%d: reconcile member: %s: error: %s", b.config.ID, m.Name, err)
 	}
 	return nil
 }
@@ -359,6 +359,9 @@ func (b *Broker) handleDeregisterMember(reason string, member serf.Member) error
 	}
 
 	log.Info.Printf("leader/%d: member is deregistering: reason: %s; node: %s", b.config.ID, reason, meta.ID)
+	if err := b.handleFailedMember(member); err != nil {
+		return err
+	}
 	req := structs.DeregisterNodeRequest{
 		Node: structs.Node{Node: meta.ID.Int32()},
 	}
@@ -476,10 +479,15 @@ func (b *Broker) handleFailedMember(m serf.Member) error {
 
 	// TODO: add an index for this. have same code in broker.go:handleMetadata(...)
 	var passing []*structs.Node
+	passingByID := make(map[int32]*structs.Node)
 	for _, n := range nodes {
-		if n.Check.Status == structs.HealthPassing && n.ID != meta.ID.Int32() {
+		if n.Check != nil && n.Check.Status == structs.HealthPassing && n.Node != meta.ID.Int32() {
 			passing = append(passing, n)
+			passingByID[n.Node] = n
 		}
+	}
+	if len(passing) == 0 {
+		return nil
 	}
 
 	// reassign consumer group coordinators
@@ -505,12 +513,6 @@ func (b *Broker) handleFailedMember(m serf.Member) error {
 		// TODO: LiveLeaders, ControllerEpoch
 	}
 	for _, p := range partitions {
-		i := rand.Intn(len(passing))
-		// TODO: check that old leader won't be in this list, will have been deregistered removed from fsm
-		node := passing[i]
-
-		// TODO: need to check replication factor
-
 		var ar []int32
 		for _, r := range p.AR {
 			if r != meta.ID.Int32() {
@@ -524,50 +526,85 @@ func (b *Broker) handleFailedMember(m serf.Member) error {
 			}
 		}
 
+		node := nextPartitionLeader(isr, ar, passingByID)
+		if node == nil {
+			log.Error.Printf("leader/%d: no passing replica candidate for partition reassignment: topic=%s partition=%d ar=%v isr=%v", b.config.ID, p.Topic, p.Partition, ar, isr)
+			continue
+		}
+
 		// TODO: need to update epochs
 
+		updatedPartition := structs.Partition{
+			Topic:     p.Topic,
+			ID:        p.Partition,
+			Partition: p.Partition,
+			Leader:    node.Node,
+			AR:        ar,
+			ISR:       isr,
+		}
 		req := structs.RegisterPartitionRequest{
-			Partition: structs.Partition{
-				Topic:     p.Topic,
-				ID:        p.Partition,
-				Partition: p.Partition,
-				Leader:    node.Node,
-				AR:        ar,
-				ISR:       isr,
-			},
+			Partition: updatedPartition,
 		}
 		if _, err = b.raftApply(structs.RegisterPartitionRequestType, req); err != nil {
 			return err
 		}
 		// TODO: need to send on leader and isr changes now i think
 		leaderAndISRReq.PartitionStates = append(leaderAndISRReq.PartitionStates, &protocol.PartitionState{
-			Topic:     p.Topic,
-			Partition: p.Partition,
+			Topic:     updatedPartition.Topic,
+			Partition: updatedPartition.Partition,
 			// TODO: ControllerEpoch, LeaderEpoch, ZKVersion - lol
-			Leader:   p.Leader,
-			ISR:      p.ISR,
-			Replicas: p.AR,
+			Leader:   updatedPartition.Leader,
+			ISR:      updatedPartition.ISR,
+			Replicas: updatedPartition.AR,
 		})
 	}
 
-	// TODO: optimize this to send requests to only nodes affected
-	for _, n := range passing {
-		broker := b.brokerLookup.BrokerByID(raft.ServerID(fmt.Sprintf("%d", n.Node)))
-		if broker == nil {
-			// TODO: this probably shouldn't happen -- likely a root issue to fix
-			log.Error.Printf("trying to assign partitions to unknown broker: %s", n)
-			continue
+	if len(leaderAndISRReq.PartitionStates) > 0 {
+		targets := make(map[int32]bool)
+		for _, n := range passing {
+			targets[n.Node] = true
 		}
-		conn, err := defaultDialer.Dial("tcp", broker.BrokerAddr)
-		if err != nil {
-			return err
+		for _, p := range leaderAndISRReq.PartitionStates {
+			for _, replica := range p.Replicas {
+				targets[replica] = true
+			}
 		}
-		_, err = conn.LeaderAndISR(leaderAndISRReq)
-		if err != nil {
-			return err
+
+		// TODO: optimize this to send requests to only nodes affected
+		for nodeID := range targets {
+			broker := b.brokerLookup.BrokerByID(raft.ServerID(fmt.Sprintf("%d", nodeID)))
+			if broker == nil {
+				// TODO: this probably shouldn't happen -- likely a root issue to fix
+				log.Error.Printf("trying to assign partitions to unknown broker: %d", nodeID)
+				continue
+			}
+			conn, err := defaultDialer.Dial("tcp", broker.BrokerAddr)
+			if err != nil {
+				log.Error.Printf("leader/%d: leader and isr fanout to broker %d failed: %s", b.config.ID, nodeID, err)
+				continue
+			}
+			_, err = conn.LeaderAndISR(leaderAndISRReq)
+			if err != nil {
+				log.Error.Printf("leader/%d: leader and isr fanout to broker %d failed: %s", b.config.ID, nodeID, err)
+				continue
+			}
 		}
 	}
 
+	return nil
+}
+
+func nextPartitionLeader(isr, ar []int32, passing map[int32]*structs.Node) *structs.Node {
+	for _, replica := range isr {
+		if node := passing[replica]; node != nil {
+			return node
+		}
+	}
+	for _, replica := range ar {
+		if node := passing[replica]; node != nil {
+			return node
+		}
+	}
 	return nil
 }
 

--- a/jocko/replicator.go
+++ b/jocko/replicator.go
@@ -48,13 +48,15 @@ func NewReplicator(config ReplicatorConfig, replica *Replica, leader client) *Re
 		msgs:    make(chan []byte, 2),
 		backoff: bo,
 	}
+	if replica != nil && replica.Log != nil {
+		r.offset = replica.Log.NewestOffset()
+	}
 	return r
 }
 
 // Replicate start fetching messages from the leader and appending them to the local commit log.
 func (r *Replicator) Replicate() {
 	go r.fetchMessages()
-	go r.appendMessages()
 }
 
 func (r *Replicator) fetchMessages() {
@@ -90,15 +92,18 @@ func (r *Replicator) fetchMessages() {
 						log.Error.Printf("replicator: partition response error: %d", p.ErrorCode)
 						goto BACKOFF
 					}
-					if p.RecordSet == nil {
+					if len(p.RecordSet) == 0 {
+						r.highwaterMarkOffset = p.HighWatermark
+						r.backoff.Reset()
+						r.sleepEmptyFetch()
+						continue
+					}
+					if err := appendRecordSetEntries(r.replica.Log, p.RecordSet); err != nil {
+						log.Error.Printf("replicator: append messages error: %s", err)
 						goto BACKOFF
 					}
-					offset := int64(protocol.Encoding.Uint64(p.RecordSet[:8]))
-					if offset > r.offset {
-						r.msgs <- p.RecordSet
-						r.highwaterMarkOffset = p.HighWatermark
-						r.offset = offset
-					}
+					r.highwaterMarkOffset = p.HighWatermark
+					r.offset = r.replica.Log.NewestOffset()
 				}
 			}
 
@@ -109,6 +114,36 @@ func (r *Replicator) fetchMessages() {
 			time.Sleep(r.backoff.NextBackOff())
 		}
 	}
+}
+
+func appendRecordSetEntries(log CommitLog, recordSet []byte) error {
+	for pos := 0; pos < len(recordSet); {
+		d := protocol.NewDecoder(recordSet[pos:])
+		if _, err := d.Int64(); err != nil {
+			return err
+		}
+		size, err := d.Int32()
+		if err != nil {
+			return err
+		}
+		end := pos + d.Offset() + int(size)
+		if end > len(recordSet) {
+			return protocol.ErrInsufficientData
+		}
+		if _, err := log.Append(recordSet[pos:end]); err != nil {
+			return err
+		}
+		pos = end
+	}
+	return nil
+}
+
+func (r *Replicator) sleepEmptyFetch() {
+	sleep := r.config.MaxWaitTime
+	if sleep <= 0 {
+		sleep = 10 * time.Millisecond
+	}
+	time.Sleep(sleep)
 }
 
 func (r *Replicator) appendMessages() {

--- a/jocko/replicator_test.go
+++ b/jocko/replicator_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/travisjeffery/jocko/jocko"
 	"github.com/travisjeffery/jocko/jocko/structs"
 	"github.com/travisjeffery/jocko/mock"
+	"github.com/travisjeffery/jocko/protocol"
 	"github.com/travisjeffery/jocko/testutil"
 )
 
@@ -52,6 +53,171 @@ func TestBroker_Replicate(t *testing.T) {
 	require.NoError(t, replicator.Close())
 }
 
+func TestReplicatorReplicatesOffsetZero(t *testing.T) {
+	c := newCommitLog()
+	l := &replicatorClient{
+		fetch: func(req *protocol.FetchRequest) (*protocol.FetchResponse, error) {
+			if req.Topics[0].Partitions[0].FetchOffset > 0 {
+				return emptyFetchResponse(req), nil
+			}
+			return fetchResponse(req, mustMessageSet(t, 0, "first"), 1), nil
+		},
+	}
+	replicator := jocko.NewReplicator(jocko.ReplicatorConfig{
+		MinBytes:    1,
+		MaxWaitTime: 25 * time.Millisecond,
+	}, testReplica(c), l)
+	replicator.Replicate()
+	defer replicator.Close()
+
+	testutil.WaitForResult(func() (bool, error) {
+		return len(c.Log()) == 1, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+	require.Equal(t, int64(0), l.fetchOffsets[0])
+}
+
+func TestReplicatorIgnoresEmptyFetchResponses(t *testing.T) {
+	c := newCommitLog()
+	l := &replicatorClient{
+		fetch: func(req *protocol.FetchRequest) (*protocol.FetchResponse, error) {
+			return emptyFetchResponse(req), nil
+		},
+	}
+	replicator := jocko.NewReplicator(jocko.ReplicatorConfig{
+		MinBytes:    1,
+		MaxWaitTime: 25 * time.Millisecond,
+	}, testReplica(c), l)
+	replicator.Replicate()
+	defer replicator.Close()
+
+	time.Sleep(100 * time.Millisecond)
+	require.Empty(t, c.Log())
+}
+
+func TestReplicatorAdvancesFetchOffsetAfterAppend(t *testing.T) {
+	c := newCommitLog()
+	messages := map[int64][]byte{
+		0: mustMessageSet(t, 0, "first"),
+		1: mustMessageSet(t, 1, "second"),
+	}
+	l := &replicatorClient{
+		fetch: func(req *protocol.FetchRequest) (*protocol.FetchResponse, error) {
+			offset := req.Topics[0].Partitions[0].FetchOffset
+			recordSet, ok := messages[offset]
+			if !ok {
+				return emptyFetchResponse(req), nil
+			}
+			return fetchResponse(req, recordSet, offset+1), nil
+		},
+	}
+	replicator := jocko.NewReplicator(jocko.ReplicatorConfig{
+		MinBytes:    1,
+		MaxWaitTime: 25 * time.Millisecond,
+	}, testReplica(c), l)
+	replicator.Replicate()
+	defer replicator.Close()
+
+	testutil.WaitForResult(func() (bool, error) {
+		return len(c.Log()) == 2, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+	require.Contains(t, l.fetchOffsets, int64(0))
+	require.Contains(t, l.fetchOffsets, int64(1))
+}
+
+func TestReplicatorSplitsFetchedRecordSetEntries(t *testing.T) {
+	c := newCommitLog()
+	l := &replicatorClient{
+		fetch: func(req *protocol.FetchRequest) (*protocol.FetchResponse, error) {
+			if req.Topics[0].Partitions[0].FetchOffset > 0 {
+				return emptyFetchResponse(req), nil
+			}
+			recordSet := bytes.Join([][]byte{
+				mustMessageSet(t, 0, "first"),
+				mustMessageSet(t, 1, "second"),
+			}, nil)
+			return fetchResponse(req, recordSet, 2), nil
+		},
+	}
+	replicator := jocko.NewReplicator(jocko.ReplicatorConfig{
+		MinBytes:    1,
+		MaxWaitTime: 25 * time.Millisecond,
+	}, testReplica(c), l)
+	replicator.Replicate()
+	defer replicator.Close()
+
+	testutil.WaitForResult(func() (bool, error) {
+		return len(c.Log()) == 2, nil
+	}, func(err error) {
+		t.Fatalf("err: %v", err)
+	})
+	require.Contains(t, l.fetchOffsets, int64(0))
+	require.Contains(t, l.fetchOffsets, int64(2))
+}
+
+type replicatorClient struct {
+	fetch        func(req *protocol.FetchRequest) (*protocol.FetchResponse, error)
+	fetchOffsets []int64
+}
+
+func (c *replicatorClient) Fetch(req *protocol.FetchRequest) (*protocol.FetchResponse, error) {
+	c.fetchOffsets = append(c.fetchOffsets, req.Topics[0].Partitions[0].FetchOffset)
+	return c.fetch(req)
+}
+
+func (c *replicatorClient) CreateTopics(req *protocol.CreateTopicRequests) (*protocol.CreateTopicsResponse, error) {
+	return nil, nil
+}
+
+func (c *replicatorClient) LeaderAndISR(req *protocol.LeaderAndISRRequest) (*protocol.LeaderAndISRResponse, error) {
+	return nil, nil
+}
+
+func testReplica(c jocko.CommitLog) *jocko.Replica {
+	return &jocko.Replica{
+		Partition: structs.Partition{
+			Topic:  "test",
+			ID:     0,
+			Leader: 1,
+			AR:     []int32{1, 2},
+			ISR:    []int32{1, 2},
+		},
+		BrokerID: 2,
+		Log:      c,
+	}
+}
+
+func fetchResponse(req *protocol.FetchRequest, recordSet []byte, highWatermark int64) *protocol.FetchResponse {
+	return &protocol.FetchResponse{
+		Responses: protocol.FetchTopicResponses{{
+			Topic: req.Topics[0].Topic,
+			PartitionResponses: []*protocol.FetchPartitionResponse{{
+				Partition:     req.Topics[0].Partitions[0].Partition,
+				ErrorCode:     protocol.ErrNone.Code(),
+				HighWatermark: highWatermark,
+				RecordSet:     recordSet,
+			}},
+		}},
+	}
+}
+
+func emptyFetchResponse(req *protocol.FetchRequest) *protocol.FetchResponse {
+	return fetchResponse(req, []byte{}, 0)
+}
+
+func mustMessageSet(t *testing.T, offset int64, value string) []byte {
+	t.Helper()
+	b, err := protocol.Encode(&protocol.MessageSet{
+		Offset:   offset,
+		Messages: []*protocol.Message{{Value: []byte(value)}},
+	})
+	require.NoError(t, err)
+	return b
+}
+
 type commitLog struct {
 	*mock.CommitLog
 	sync.RWMutex
@@ -72,8 +238,9 @@ func newCommitLog() *commitLog {
 		AppendFunc: func(b []byte) (int64, error) {
 			c.Lock()
 			c.b = append(c.b, b)
+			offset := int64(len(c.b) - 1)
 			c.Unlock()
-			return 0, nil
+			return offset, nil
 		},
 		DeleteFunc: func() error {
 			return nil
@@ -86,7 +253,9 @@ func newCommitLog() *commitLog {
 		},
 
 		NewestOffsetFunc: func() int64 {
-			return 0
+			c.RLock()
+			defer c.RUnlock()
+			return int64(len(c.b))
 		},
 
 		OldestOffsetFunc: func() int64 {

--- a/jocko/server_test.go
+++ b/jocko/server_test.go
@@ -259,6 +259,110 @@ func TestKafkaConsumerGroupMultiMemberRebalance(t *testing.T) {
 	}
 }
 
+func TestKafkaReplicatedPartitionLeaderFailover(t *testing.T) {
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+	s1, dir1 := jocko.NewTestServer(t, func(cfg *config.Config) {
+		cfg.Bootstrap = true
+		cfg.BootstrapExpect = 3
+	}, nil)
+	defer os.RemoveAll(dir1)
+	require.NoError(t, s1.Start(ctx1))
+	defer s1.Shutdown()
+
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	s2, dir2 := jocko.NewTestServer(t, func(cfg *config.Config) {
+		cfg.Bootstrap = false
+		cfg.BootstrapExpect = 3
+	}, nil)
+	defer os.RemoveAll(dir2)
+	require.NoError(t, s2.Start(ctx2))
+	defer s2.Shutdown()
+
+	ctx3, cancel3 := context.WithCancel(context.Background())
+	defer cancel3()
+	s3, dir3 := jocko.NewTestServer(t, func(cfg *config.Config) {
+		cfg.Bootstrap = false
+		cfg.BootstrapExpect = 3
+	}, nil)
+	defer os.RemoveAll(dir3)
+	require.NoError(t, s3.Start(ctx3))
+	defer s3.Shutdown()
+
+	jocko.TestJoin(t, s1, s2, s3)
+	controller, followers := jocko.WaitForLeader(t, s1, s2, s3)
+	jocko.WaitForLiveNodes(t, s1, s2, s3)
+	retry.RunWith(&retry.Timer{Timeout: 10 * time.Second, Wait: 50 * time.Millisecond}, t, func(r *retry.R) {
+		r.Check(createTopic(t, controller, followers...))
+	})
+
+	servers := map[int32]*jocko.Server{
+		s1.ID(): s1,
+		s2.ID(): s2,
+		s3.ID(): s3,
+	}
+	cancels := map[int32]context.CancelFunc{
+		s1.ID(): cancel1,
+		s2.ID(): cancel2,
+		s3.ID(): cancel3,
+	}
+	brokers := []string{s1.Addr().String(), s2.Addr().String(), s3.Addr().String()}
+	waitForTopicReplication(t, brokers, 3, 3, 10*time.Second)
+	oldLeader := waitForPartitionLeader(t, brokers, -1, 10*time.Second)
+
+	producer := newManualProducer(t, []string{oldLeader.Addr()})
+	defer producer.Close()
+
+	firstValues := [][]byte{
+		[]byte("failover-before-0"),
+		[]byte("failover-before-1"),
+		[]byte("failover-before-2"),
+	}
+	for _, value := range firstValues {
+		partition, _, err := producer.SendMessage(&sarama.ProducerMessage{
+			Topic:     topic,
+			Partition: 0,
+			Value:     sarama.ByteEncoder(value),
+		})
+		require.NoError(t, err)
+		require.Equal(t, int32(0), partition)
+	}
+
+	waitForFetchHighWatermark(t, oldLeader.Addr(), 3, 10*time.Second)
+
+	leaderServer := servers[oldLeader.ID()]
+	require.NotNil(t, leaderServer)
+	require.NoError(t, leaderServer.Leave())
+	require.NoError(t, leaderServer.Shutdown())
+	cancels[oldLeader.ID()]()
+
+	var remainingBrokers []string
+	for id, srv := range servers {
+		if id != oldLeader.ID() {
+			remainingBrokers = append(remainingBrokers, srv.Addr().String())
+		}
+	}
+	newLeader := waitForPartitionLeader(t, remainingBrokers, oldLeader.ID(), 10*time.Second)
+	waitForFetchHighWatermark(t, newLeader.Addr(), 3, 10*time.Second)
+
+	assertPartitionValues(t, newLeader.Addr(), firstValues, 10*time.Second)
+
+	postProducer := newManualProducer(t, []string{newLeader.Addr()})
+	defer postProducer.Close()
+	afterValue := []byte("failover-after")
+	partition, _, err := postProducer.SendMessage(&sarama.ProducerMessage{
+		Topic:     topic,
+		Partition: 0,
+		Value:     sarama.ByteEncoder(afterValue),
+	})
+	require.NoError(t, err)
+	require.Equal(t, int32(0), partition)
+	waitForFetchHighWatermark(t, newLeader.Addr(), 4, 10*time.Second)
+
+	assertPartitionValues(t, newLeader.Addr(), append(firstValues, afterValue), 10*time.Second)
+}
+
 func consumerGroupConfig(clientID string) *cluster.Config {
 	config := cluster.NewConfig()
 	config.ClientID = clientID
@@ -267,6 +371,220 @@ func consumerGroupConfig(clientID string) *cluster.Config {
 	config.Consumer.Offsets.Initial = sarama.OffsetOldest
 	config.Consumer.Return.Errors = true
 	return config
+}
+
+func newManualProducer(t *testing.T, brokers []string) sarama.SyncProducer {
+	t.Helper()
+
+	config := sarama.NewConfig()
+	config.ClientID = "kafka-replicated-partition-producer"
+	config.Version = sarama.V0_10_0_0
+	config.Producer.Return.Successes = true
+	config.Producer.RequiredAcks = sarama.WaitForAll
+	config.Producer.Retry.Max = 10
+	config.Producer.Partitioner = sarama.NewManualPartitioner
+	producer, err := sarama.NewSyncProducer(brokers, config)
+	require.NoError(t, err)
+	return producer
+}
+
+func waitForPartitionLeader(t *testing.T, brokers []string, previousLeader int32, timeout time.Duration) *sarama.Broker {
+	t.Helper()
+
+	config := sarama.NewConfig()
+	config.ClientID = "kafka-replicated-partition-metadata"
+	config.Version = sarama.V0_10_0_0
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		client, err := sarama.NewClient(brokers, config)
+		if err != nil {
+			lastErr = err
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		leader, err := client.Leader(topic, 0)
+		if err == nil && leader != nil && leader.ID() != previousLeader {
+			_ = client.Close()
+			return leader
+		}
+		if err != nil {
+			lastErr = err
+		}
+		_ = client.Close()
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for partition leader after %d: %v", previousLeader, lastErr)
+	return nil
+}
+
+func waitForTopicReplication(t *testing.T, brokers []string, replicas, isr int, timeout time.Duration) {
+	t.Helper()
+
+	config := sarama.NewConfig()
+	config.ClientID = "kafka-replicated-partition-replicas"
+	config.Version = sarama.V0_10_0_0
+	deadline := time.Now().Add(timeout)
+	var lastReplicas, lastISR []int32
+	var lastLeader *sarama.Broker
+	var lastErr error
+	for time.Now().Before(deadline) {
+		client, err := sarama.NewClient(brokers, config)
+		if err != nil {
+			lastErr = err
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		lastLeader, err = client.Leader(topic, 0)
+		if err != nil {
+			lastErr = err
+			_ = client.Close()
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		lastReplicas, err = client.Replicas(topic, 0)
+		if err != nil {
+			lastErr = err
+			_ = client.Close()
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		lastISR, err = client.InSyncReplicas(topic, 0)
+		if err != nil {
+			lastErr = err
+			_ = client.Close()
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		_ = client.Close()
+		if lastLeader != nil && len(lastReplicas) == replicas && len(lastISR) == isr {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for topic replication replicas=%d isr=%d, got leader=%v replicas=%v isr=%v err=%v", replicas, isr, lastLeader, lastReplicas, lastISR, lastErr)
+}
+
+func waitForFetchHighWatermark(t *testing.T, brokerAddr string, want int64, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	var last int64
+	var lastErr error
+	for time.Now().Before(deadline) {
+		conn, err := (&jocko.Dialer{Timeout: time.Second, ClientID: "kafka-replicated-partition-fetch"}).Dial("tcp", brokerAddr)
+		if err != nil {
+			lastErr = err
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		res, err := conn.Fetch(&protocol.FetchRequest{
+			MaxWaitTime: 100 * time.Millisecond,
+			ReplicaID:   -1,
+			MinBytes:    1,
+			Topics: []*protocol.FetchTopic{{
+				Topic: topic,
+				Partitions: []*protocol.FetchPartition{{
+					Partition:   0,
+					FetchOffset: 0,
+					MaxBytes:    1024 * 1024,
+				}},
+			}},
+		})
+		_ = conn.Close()
+		if err != nil {
+			lastErr = err
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		last = res.Responses[0].PartitionResponses[0].HighWatermark
+		if last >= want {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for high watermark >= %d, got %d: %v", want, last, lastErr)
+}
+
+func assertPartitionValues(t *testing.T, brokerAddr string, want [][]byte, timeout time.Duration) {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+	var got [][]byte
+	var lastErr error
+	for time.Now().Before(deadline) {
+		conn, err := (&jocko.Dialer{Timeout: time.Second, ClientID: "kafka-replicated-partition-consumer"}).Dial("tcp", brokerAddr)
+		if err != nil {
+			lastErr = err
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		res, err := conn.Fetch(&protocol.FetchRequest{
+			MaxWaitTime: 100 * time.Millisecond,
+			ReplicaID:   -1,
+			MinBytes:    1,
+			Topics: []*protocol.FetchTopic{{
+				Topic: topic,
+				Partitions: []*protocol.FetchPartition{{
+					Partition:   0,
+					FetchOffset: 0,
+					MaxBytes:    1024 * 1024,
+				}},
+			}},
+		})
+		_ = conn.Close()
+		if err != nil {
+			lastErr = err
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		require.Len(t, res.Responses, 1)
+		require.Len(t, res.Responses[0].PartitionResponses, 1)
+		pres := res.Responses[0].PartitionResponses[0]
+		if pres.ErrorCode != protocol.ErrNone.Code() {
+			lastErr = protocol.Errs[pres.ErrorCode]
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		got, err = decodeRecordSetValues(pres.RecordSet)
+		if err != nil {
+			lastErr = err
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		if len(got) >= len(want) {
+			require.Equal(t, want, got[:len(want)])
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for partition values: want=%q got=%q err=%v", want, got, lastErr)
+}
+
+func decodeRecordSetValues(recordSet []byte) ([][]byte, error) {
+	values := make([][]byte, 0)
+	for pos := 0; pos < len(recordSet); {
+		d := protocol.NewDecoder(recordSet[pos:])
+		if _, err := d.Int64(); err != nil {
+			return nil, err
+		}
+		size, err := d.Int32()
+		if err != nil {
+			return nil, err
+		}
+		start := pos + d.Offset()
+		end := start + int(size)
+		if end > len(recordSet) {
+			return nil, protocol.ErrInsufficientData
+		}
+		msg := new(protocol.Message)
+		if err := msg.Decode(protocol.NewDecoder(recordSet[start:end])); err != nil {
+			return nil, err
+		}
+		values = append(values, msg.Value)
+		pos = end
+	}
+	return values, nil
 }
 
 func waitForConsumerPartitions(t *testing.T, consumer *cluster.Consumer, want int, timeout time.Duration) map[int32]bool {
@@ -803,8 +1121,12 @@ func createTopicWithPartitions(t ti.T, s1 *jocko.Server, partitions int32, other
 		return err
 	}
 	assignment := []int32{s1.ID()}
+	seenAssignments := map[int32]bool{s1.ID(): true}
 	for _, o := range other {
-		assignment = append(assignment, o.ID())
+		if !seenAssignments[o.ID()] {
+			assignment = append(assignment, o.ID())
+			seenAssignments[o.ID()] = true
+		}
 	}
 	replicaAssignment := make(map[int32][]int32, partitions)
 	for partition := int32(0); partition < partitions; partition++ {

--- a/jocko/testing.go
+++ b/jocko/testing.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mitchellh/go-testing-interface"
 	dynaport "github.com/travisjeffery/go-dynaport"
 	"github.com/travisjeffery/jocko/jocko/config"
+	"github.com/travisjeffery/jocko/jocko/structs"
 
 	"github.com/uber/jaeger-lib/metrics"
 
@@ -112,6 +113,8 @@ func WaitForLeader(t testing.T, servers ...*Server) (*Server, []*Server) {
 		followers map[*Server]bool
 	}{nil, make(map[*Server]bool)}
 	retry.Run(t, func(r *retry.R) {
+		tmp.leader = nil
+		tmp.followers = make(map[*Server]bool)
 		for _, s := range servers {
 			if raft.Leader == s.handler.(*Broker).raft.State() {
 				tmp.leader = s
@@ -128,4 +131,27 @@ func WaitForLeader(t testing.T, servers ...*Server) (*Server, []*Server) {
 		followers = append(followers, f)
 	}
 	return tmp.leader, followers
+}
+
+func WaitForLiveNodes(t testing.T, servers ...*Server) {
+	retry.RunWith(&retry.Timer{Timeout: 10 * time.Second, Wait: 50 * time.Millisecond}, t, func(r *retry.R) {
+		for _, s := range servers {
+			_, nodes, err := s.handler.(*Broker).fsm.State().GetNodes()
+			if err != nil {
+				r.Fatalf("get nodes: %v", err)
+			}
+
+			live := make(map[int32]bool, len(nodes))
+			for _, node := range nodes {
+				if node.Check != nil && node.Check.Status == structs.HealthPassing {
+					live[node.Node] = true
+				}
+			}
+			for _, want := range servers {
+				if !live[want.ID()] {
+					r.Fatalf("server %d does not see live node %d: %v", s.ID(), want.ID(), live)
+				}
+			}
+		}
+	})
 }

--- a/mock/proxy.go
+++ b/mock/proxy.go
@@ -27,9 +27,14 @@ func (p *Client) Fetch(fetchRequest *protocol.FetchRequest) (*protocol.FetchResp
 	if len(p.msgs) >= p.msgCount {
 		return &protocol.FetchResponse{}, nil
 	}
-	msgs := [][]byte{
-		[]byte("msg " + strconv.Itoa(len(p.msgs))),
+	msg, err := protocol.Encode(&protocol.MessageSet{
+		Offset:   int64(len(p.msgs)),
+		Messages: []*protocol.Message{{Value: []byte("msg " + strconv.Itoa(len(p.msgs)))}},
+	})
+	if err != nil {
+		return nil, err
 	}
+	msgs := [][]byte{msg}
 	response := &protocol.FetchResponse{
 		Responses: protocol.FetchTopicResponses{{
 			Topic: fetchRequest.Topics[0].Topic,


### PR DESCRIPTION
## Summary
- add runtime ISR/high-watermark tracking for replicated partitions
- preserve local replica logs across LeaderAndISR role changes and fix follower replication offset handling
- reassign partition leadership on graceful broker leave and prove failover with a 3-broker e2e

## Validation
- go test ./jocko -run 'TestKafkaReplicatedPartitionLeaderFailover|TestBroker_LeftLeader|TestKafkaConsumerGroup' -count=1 -v -timeout=3m
- go test ./...